### PR TITLE
fix

### DIFF
--- a/dashboard_viewer/tabsManager/templatetags/custom_tags.py
+++ b/dashboard_viewer/tabsManager/templatetags/custom_tags.py
@@ -1,5 +1,6 @@
-from django import template
 from pydoc import locate
+
+from django import template
 
 register = template.Library()
 

--- a/dashboard_viewer/tabsManager/templatetags/custom_tags.py
+++ b/dashboard_viewer/tabsManager/templatetags/custom_tags.py
@@ -1,8 +1,9 @@
 from django import template
+from pydoc import locate
 
 register = template.Library()
 
 
 @register.filter
 def isinst(val, class_str):
-    return isinstance(val, class_str)
+    return isinstance(val, locate(class_str))


### PR DESCRIPTION
Fix a bug in tabs app

## Description
After running github actions, some changes were requested that lead to the a unnoticed bug when calling `isinstance` on the tabs template.
We were providing a string to the second argument which needs to be a type or a list of types.

## Related Issue
None

## Motivation and Context
Bug

## How Has This Been Tested?
Not applicable yet
