### PR TITLE
Fix a bug on database_type

### DIFF
--- a/dashboard_viewer/uploader/forms.py
+++ b/dashboard_viewer/uploader/forms.py
@@ -20,7 +20,7 @@ class SourceForm(forms.ModelForm):
         }
 
     def clean_database_type(self):
-        return self.cleaned_data["database_type"].title()
+        return self.cleaned_data["database_type"].trim().title()
 
 
 class AchillesResultsForm(forms.Form):

--- a/dashboard_viewer/uploader/forms.py
+++ b/dashboard_viewer/uploader/forms.py
@@ -7,19 +7,15 @@ from .widgets import ListTextWidget
 
 
 class SourceForm(forms.ModelForm):
-    database_type = forms.CharField(
-        max_length=40,
-        widget=ListTextWidget(DatabaseType.objects),
-        help_text="Type of the data source. You can create a new type.",
-    )
     coordinates = CoordinatesField(
         help_text="Coordinates for the location of the data source"
     )
 
     class Meta:
         model = DataSource
-        fields = ("name", "acronym", "release_date", "country", "link")
+        fields = ("name", "acronym", "release_date", "country", "link", "database_type")
         widgets = {
+            "database_type": ListTextWidget(DatabaseType.objects),
             "release_date": DatePickerInput(),  # format %m/%d/%Y. Using a ModelForm this can't be changed
         }
 


### PR DESCRIPTION
## Description
One of the github actions requested to change the `exclude` field of the `Meta` class of the `SourceForm` on the forms.py of the uploader app.
With this request I didn't added the field `database_type` to the field `fields`.

## Related Issue
None

## Motivation and Context
`database_type` field being empty after a datasource is created.

## How Has This Been Tested?
Not applicable yet
