### PR TITLE
fix/Register UploadHistory in admin

### DIFF
--- a/dashboard_viewer/materialized_queries_manager/admin.py
+++ b/dashboard_viewer/materialized_queries_manager/admin.py
@@ -2,6 +2,10 @@ from django.contrib import admin
 
 from .models import MaterializedQuery
 
+
 @admin.register(MaterializedQuery)
 class MaterializedQueryAdmin(admin.ModelAdmin):
-    list_display = ("name", "dashboards",)
+    list_display = (
+        "name",
+        "dashboards",
+    )

--- a/dashboard_viewer/materialized_queries_manager/admin.py
+++ b/dashboard_viewer/materialized_queries_manager/admin.py
@@ -2,4 +2,6 @@ from django.contrib import admin
 
 from .models import MaterializedQuery
 
-admin.site.register(MaterializedQuery)
+@admin.register(MaterializedQuery)
+class MaterializedQueryAdmin(admin.ModelAdmin):
+    list_display = ("name", "dashboards",)

--- a/dashboard_viewer/tabsManager/admin.py
+++ b/dashboard_viewer/tabsManager/admin.py
@@ -10,6 +10,6 @@ class TabAdmin(admin.ModelAdmin):
 
 
 @admin.register(TabGroup)
-class TabAdmin(admin.ModelAdmin):
+class TabGroupAdmin(admin.ModelAdmin):
     list_display = ("title", "position", "visible")
     list_filter = ("visible",)

--- a/dashboard_viewer/tabsManager/admin.py
+++ b/dashboard_viewer/tabsManager/admin.py
@@ -2,5 +2,14 @@ from django.contrib import admin
 
 from .models import Tab, TabGroup
 
-admin.site.register(Tab)
-admin.site.register(TabGroup)
+
+@admin.register(Tab)
+class TabAdmin(admin.ModelAdmin):
+    list_display = ("title", "position", "visible", "group")
+    list_filter = ("visible",)
+
+
+@admin.register(TabGroup)
+class TabAdmin(admin.ModelAdmin):
+    list_display = ("title", "position", "visible")
+    list_filter = ("visible",)

--- a/dashboard_viewer/uploader/admin.py
+++ b/dashboard_viewer/uploader/admin.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
 
-from .models import Country, DatabaseType, DataSource
+from .models import Country, DatabaseType, DataSource, UploadHistory
 
 admin.site.register(DataSource)
 admin.site.register(Country)
 admin.site.register(DatabaseType)
+admin.site.register(UploadHistory)

--- a/dashboard_viewer/uploader/admin.py
+++ b/dashboard_viewer/uploader/admin.py
@@ -5,4 +5,11 @@ from .models import Country, DatabaseType, DataSource, UploadHistory
 admin.site.register(DataSource)
 admin.site.register(Country)
 admin.site.register(DatabaseType)
-admin.site.register(UploadHistory)
+
+
+@admin.register(UploadHistory)
+class UploadHistoryAdmin(admin.ModelAdmin):
+    list_display = ("data_source", "upload_date")
+
+    def has_add_permission(self, *_, **__):
+        return False

--- a/dashboard_viewer/uploader/models.py
+++ b/dashboard_viewer/uploader/models.py
@@ -92,6 +92,12 @@ class UploadHistory(models.Model):
     cdm_version = models.CharField(max_length=10)
     vocabulary_version = models.CharField(max_length=10)
 
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        return f"{self.data_source.name} - {self.upload_date}"
+
 
 class AchillesResults(models.Model):
     class Meta:


### PR DESCRIPTION
Use Admin models to choose the output of models on the admin app instead of simply their string representation.

Before:
![before](https://user-images.githubusercontent.com/23409890/96251411-5599d780-0fa8-11eb-89ac-87a89dfc9fec.png)

After:
![after](https://user-images.githubusercontent.com/23409890/96251428-5b8fb880-0fa8-11eb-96c8-620c63773e05.png)
