### PR TITLE
imp/Error pages + Save logs on production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# dashboard_viewer django app ERRORs logs
+logs
+
 # custom file created at docker/superset
 docker-init.sh
 

--- a/dashboard_viewer/dashboard_viewer/settings.py
+++ b/dashboard_viewer/dashboard_viewer/settings.py
@@ -28,6 +28,37 @@ SECRET_KEY = os.environ["SECRET_KEY"]
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DASHBOARD_VIEWER_ENV", "development") == "development"
 
+
+_LOGS_DIR = os.path.join(BASE_DIR, "logs")
+if not os.path.exists(_LOGS_DIR):
+    os.makedirs(_LOGS_DIR, exist_ok=True)
+elif not os.path.isdir(_LOGS_DIR):
+    raise TypeError('file "logs" is not a directory.')
+
+LOGGING = {
+    "version": 1,
+    "filters": {
+        "require_debug_true": {
+            "()": "django.utils.log.RequireDebugTrue",
+        },
+    },
+    "handlers": {
+        "file": {
+            "level": "ERROR",
+            "filters": ["require_debug_true"],
+            "class": "logging.FileHandler",
+            "filename": "logs/errors.log",
+        }
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["file"],
+            "level": "ERROR",
+            "propagate": True,
+        },
+    },
+}
+
 ALLOWED_HOSTS = ["*"]
 
 

--- a/dashboard_viewer/dashboard_viewer/urls.py
+++ b/dashboard_viewer/dashboard_viewer/urls.py
@@ -18,6 +18,13 @@ from django.conf.urls import static
 from django.contrib import admin
 from django.urls import include, path
 
+from .views import bad_request, forbidden, not_found, server_error
+
+handler400 = bad_request
+handler403 = forbidden
+handler404 = not_found
+handler500 = server_error
+
 urlpatterns = [
     path("", include("tabsManager.urls")),
     path("admin/", admin.site.urls),

--- a/dashboard_viewer/dashboard_viewer/views.py
+++ b/dashboard_viewer/dashboard_viewer/views.py
@@ -1,0 +1,40 @@
+import constance
+from django.http import (
+    HttpResponseBadRequest,
+    HttpResponseForbidden,
+    HttpResponseNotFound,
+    HttpResponseServerError,
+)
+from django.template import loader
+
+
+def server_error(request):
+    template = loader.get_template("500.html")
+    context = {
+        "constance_config": constance.config,
+    }
+    return HttpResponseServerError(template.render(context))
+
+
+def not_found(request, exception):  # noqa
+    template = loader.get_template("404.html")
+    context = {
+        "constance_config": constance.config,
+    }
+    return HttpResponseNotFound(template.render(context))
+
+
+def forbidden(request, exception):  # noqa
+    template = loader.get_template("403.html")
+    context = {
+        "constance_config": constance.config,
+    }
+    return HttpResponseForbidden(template.render(context))
+
+
+def bad_request(request, exception):  # noqa
+    template = loader.get_template("400.html")
+    context = {
+        "constance_config": constance.config,
+    }
+    return HttpResponseBadRequest(template.render(context))

--- a/dashboard_viewer/shared/templates/400.html
+++ b/dashboard_viewer/shared/templates/400.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block head_tail %}
+    <link rel="stylesheet" href='{% static "header.css" %}' >
+    <link rel="stylesheet" href='{% static "pages.css" %}' >
+{% endblock %}
+
+{% block content %}
+    <div class="page-container">
+        {% include "header.html" %}
+
+        <div class="content-container">
+            <h1><i style="color: orangered" class="fas fa-times-circle"></i> Bad Request</h1>
+            <p>The request received was malformed or illegal.</p>
+        </div>
+    </div>
+{% endblock %}
+
+

--- a/dashboard_viewer/shared/templates/403.html
+++ b/dashboard_viewer/shared/templates/403.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block head_tail %}
+    <link rel="stylesheet" href='{% static "header.css" %}' >
+    <link rel="stylesheet" href='{% static "pages.css" %}' >
+{% endblock %}
+
+{% block content %}
+    <div class="page-container">
+        {% include "header.html" %}
+
+        <div class="content-container">
+            <h1><i style="color: dodgerblue" class="fas fa-shield-alt"></i> Forbidden</h1>
+            <p>You don't have permission to access the provided URL.</p>
+        </div>
+    </div>
+{% endblock %}
+
+

--- a/dashboard_viewer/shared/templates/404.html
+++ b/dashboard_viewer/shared/templates/404.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block head_tail %}
+    <link rel="stylesheet" href='{% static "header.css" %}' >
+    <link rel="stylesheet" href='{% static "pages.css" %}' >
+{% endblock %}
+
+{% block content %}
+    <div class="page-container">
+        {% include "header.html" %}
+
+        <div class="content-container">
+            <h1><i style="color: orange" class="fas fa-exclamation-triangle"></i> Not found</h1>
+            <p>No content was found for the specified URL.</p>
+        </div>
+    </div>
+{% endblock %}
+
+

--- a/dashboard_viewer/shared/templates/500.html
+++ b/dashboard_viewer/shared/templates/500.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block head_tail %}
+    <link rel="stylesheet" href='{% static "header.css" %}' >
+    <link rel="stylesheet" href='{% static "pages.css" %}' >
+{% endblock %}
+
+{% block content %}
+    <div class="page-container">
+        {% include "header.html" %}
+
+        <div class="content-container">
+            <h1><i style="color: red" class="fas fa-exclamation-circle"></i> Internal Server Error</h1>
+            <p>An unexpected error happened.</p>
+            <p>This will be reported and fixed as soon as possible. Please try again later.</p>
+        </div>
+    </div>
+{% endblock %}
+
+


### PR DESCRIPTION
- If on production, store ERROR logs into a log file
- Implement templates for http erros (400, 403, 404, 500):
  - 400 
![bad_request](https://user-images.githubusercontent.com/23409890/102018322-7f7f3880-3d64-11eb-8b44-aa4cfd765e9d.png)
  - 403
![forbidden](https://user-images.githubusercontent.com/23409890/102018328-84dc8300-3d64-11eb-8243-e4eb8db192e2.png)
  - 404
![not_found](https://user-images.githubusercontent.com/23409890/102018336-8c9c2780-3d64-11eb-9d4e-e2dc89ba84b7.png)
  - 500
![server_error](https://user-images.githubusercontent.com/23409890/102018340-958cf900-3d64-11eb-8931-ec6720791576.png)



