### PR TITLE
Imp/Datasource delete on task

### DIFF
--- a/dashboard_viewer/uploader/actions.py
+++ b/dashboard_viewer/uploader/actions.py
@@ -14,7 +14,12 @@ def custom_delete_selected(modeladmin, request, queryset):
     """
     opts = modeladmin.model._meta
 
-    deletable_objects, model_count, perms_needed, protected = modeladmin.get_deleted_objects(queryset, request)
+    (
+        deletable_objects,
+        model_count,
+        perms_needed,
+        protected,
+    ) = modeladmin.get_deleted_objects(queryset, request)
 
     if request.POST.get("post") and not protected:
         if perms_needed:
@@ -31,10 +36,9 @@ def custom_delete_selected(modeladmin, request, queryset):
                 _(
                     "Deleting %(count)d %(items)s on background. "
                     "In a few minutes they will stop showing on the objects list."
-                ) % {
-                    "count": n, "items": model_ngettext(modeladmin.opts, n)
-                },
-                messages.SUCCESS
+                )
+                % {"count": n, "items": model_ngettext(modeladmin.opts, n)},
+                messages.SUCCESS,
             )
         # Return None to display the change list page again.
         return None
@@ -64,11 +68,11 @@ def custom_delete_selected(modeladmin, request, queryset):
 
     # Display the confirmation page
     return TemplateResponse(
-        request,
-        "admin/datasource/delete_selected_confirmation.html",
-        context
+        request, "admin/datasource/delete_selected_confirmation.html", context
     )
 
 
-custom_delete_selected.allowed_permissions = ('delete',)
-custom_delete_selected.short_description = gettext_lazy("Delete selected %(verbose_name_plural)s")
+custom_delete_selected.allowed_permissions = ("delete",)
+custom_delete_selected.short_description = gettext_lazy(
+    "Delete selected %(verbose_name_plural)s"
+)

--- a/dashboard_viewer/uploader/actions.py
+++ b/dashboard_viewer/uploader/actions.py
@@ -1,0 +1,74 @@
+from django.contrib import messages
+from django.contrib.admin import helpers
+from django.contrib.admin.utils import model_ngettext
+from django.core.exceptions import PermissionDenied
+from django.template.response import TemplateResponse
+from django.utils.translation import gettext as _, gettext_lazy
+
+
+def custom_delete_selected(modeladmin, request, queryset):
+    """
+    Based on https://github.com/django/django/blob/2.2.17/django/contrib/admin/actions.py#L13
+    The only change was the message returned after deletion since the deletion process is
+     sent to a background task
+    """
+    opts = modeladmin.model._meta
+
+    deletable_objects, model_count, perms_needed, protected = modeladmin.get_deleted_objects(queryset, request)
+
+    if request.POST.get("post") and not protected:
+        if perms_needed:
+            raise PermissionDenied
+        n = queryset.count()
+        if n:
+            for obj in queryset:
+                obj_display = str(obj)
+                modeladmin.log_deletion(request, obj, obj_display)
+            modeladmin.delete_queryset(request, queryset)
+            # ONLY CHANGE vv
+            modeladmin.message_user(
+                request,
+                _(
+                    "Deleting %(count)d %(items)s on background. "
+                    "In a few minutes they will stop showing on the objects list."
+                ) % {
+                    "count": n, "items": model_ngettext(modeladmin.opts, n)
+                },
+                messages.SUCCESS
+            )
+        # Return None to display the change list page again.
+        return None
+
+    objects_name = model_ngettext(queryset)
+
+    if perms_needed or protected:
+        title = _("Cannot delete %(name)s") % {"name": objects_name}
+    else:
+        title = _("Are you sure?")
+
+    context = {
+        **modeladmin.admin_site.each_context(request),
+        "title": title,
+        "objects_name": str(objects_name),
+        "deletable_objects": [deletable_objects],
+        "model_count": dict(model_count).items(),
+        "queryset": queryset,
+        "perms_lacking": perms_needed,
+        "protected": protected,
+        "opts": opts,
+        "action_checkbox_name": helpers.ACTION_CHECKBOX_NAME,
+        "media": modeladmin.media,
+    }
+
+    request.current_app = modeladmin.admin_site.name
+
+    # Display the confirmation page
+    return TemplateResponse(
+        request,
+        "admin/datasource/delete_selected_confirmation.html",
+        context
+    )
+
+
+custom_delete_selected.allowed_permissions = ('delete',)
+custom_delete_selected.short_description = gettext_lazy("Delete selected %(verbose_name_plural)s")

--- a/dashboard_viewer/uploader/admin.py
+++ b/dashboard_viewer/uploader/admin.py
@@ -1,8 +1,21 @@
-from django.contrib import admin
+import json
 
+from django.contrib import admin, messages
+from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
+from django.core import serializers
+from django.http import HttpResponseRedirect
+from django.template.response import TemplateResponse
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from .actions import custom_delete_selected
 from .models import Country, DatabaseType, DataSource, UploadHistory
+from .tasks import delete_datasource
 
-admin.site.register(DataSource)
+
+IS_POPUP_VAR = '_popup'
+
+
 admin.site.register(Country)
 admin.site.register(DatabaseType)
 
@@ -13,3 +26,76 @@ class UploadHistoryAdmin(admin.ModelAdmin):
 
     def has_add_permission(self, *_, **__):
         return False
+
+
+@admin.register(DataSource)
+class DataSourceAdmin(admin.ModelAdmin):
+    list_display = ("name", "acronym", "database_type", "country")
+
+    actions = [custom_delete_selected]
+
+    def get_actions(self, request):
+        """
+        Remove the default delete selected action
+        """
+        actions = super().get_actions(request)
+        if "delete_selected" in actions:
+            del actions["delete_selected"]
+        return actions
+
+    def delete_model(self, request, obj):
+        delete_datasource.delay(
+            serializers.serialize("json", [obj])
+        )
+
+    def response_delete(self, request, obj_display, obj_id):
+        """
+        Based on https://github.com/django/django/blob/2.2.17/django/contrib/admin/options.py#L1411
+        The only change was the message returned after deletion since the deletion process is
+         sent to a background task
+        """
+        opts = self.model._meta
+
+        if IS_POPUP_VAR in request.POST:
+            popup_response_data = json.dumps({
+                "action": "delete",
+                "value": str(obj_id),
+            })
+            return TemplateResponse(request, self.popup_response_template or [
+                "admin/%s/%s/popup_response.html" % (opts.app_label, opts.model_name),
+                "admin/%s/popup_response.html" % opts.app_label,
+                "admin/popup_response.html",
+                ], {
+                                        "popup_response_data": popup_response_data,
+                                    })
+
+        self.message_user(
+            request,
+            # ONLY CHANGE vv
+            _(
+                'The %(name)s "%(obj)s" is being deleted on background. '
+                "In a few minutes it will stop appearing on the objects list."
+            ) % {
+                "name": opts.verbose_name,
+                "obj": obj_display,
+            },
+            messages.SUCCESS,
+            )
+
+        if self.has_change_permission(request, None):
+            post_url = reverse(
+                "admin:%s_%s_changelist" % (opts.app_label, opts.model_name),
+                current_app=self.admin_site.name,
+                )
+            preserved_filters = self.get_preserved_filters(request)
+            post_url = add_preserved_filters(
+                {"preserved_filters": preserved_filters, "opts": opts}, post_url
+            )
+        else:
+            post_url = reverse("admin:index", current_app=self.admin_site.name)
+        return HttpResponseRedirect(post_url)
+
+    def delete_queryset(self, request, queryset):
+        delete_datasource.delay(
+            serializers.serialize("json", [obj for obj in queryset])
+        )

--- a/dashboard_viewer/uploader/admin.py
+++ b/dashboard_viewer/uploader/admin.py
@@ -12,8 +12,7 @@ from .actions import custom_delete_selected
 from .models import Country, DatabaseType, DataSource, UploadHistory
 from .tasks import delete_datasource
 
-
-IS_POPUP_VAR = '_popup'
+IS_POPUP_VAR = "_popup"
 
 
 admin.site.register(Country)
@@ -44,9 +43,7 @@ class DataSourceAdmin(admin.ModelAdmin):
         return actions
 
     def delete_model(self, request, obj):
-        delete_datasource.delay(
-            serializers.serialize("json", [obj])
-        )
+        delete_datasource.delay(serializers.serialize("json", [obj]))
 
     def response_delete(self, request, obj_display, obj_id):
         """
@@ -57,17 +54,25 @@ class DataSourceAdmin(admin.ModelAdmin):
         opts = self.model._meta
 
         if IS_POPUP_VAR in request.POST:
-            popup_response_data = json.dumps({
-                "action": "delete",
-                "value": str(obj_id),
-            })
-            return TemplateResponse(request, self.popup_response_template or [
-                "admin/%s/%s/popup_response.html" % (opts.app_label, opts.model_name),
-                "admin/%s/popup_response.html" % opts.app_label,
-                "admin/popup_response.html",
-                ], {
-                                        "popup_response_data": popup_response_data,
-                                    })
+            popup_response_data = json.dumps(
+                {
+                    "action": "delete",
+                    "value": str(obj_id),
+                }
+            )
+            return TemplateResponse(
+                request,
+                self.popup_response_template
+                or [
+                    "admin/%s/%s/popup_response.html"
+                    % (opts.app_label, opts.model_name),
+                    "admin/%s/popup_response.html" % opts.app_label,
+                    "admin/popup_response.html",
+                ],
+                {
+                    "popup_response_data": popup_response_data,
+                },
+            )
 
         self.message_user(
             request,
@@ -75,18 +80,19 @@ class DataSourceAdmin(admin.ModelAdmin):
             _(
                 'The %(name)s "%(obj)s" is being deleted on background. '
                 "In a few minutes it will stop appearing on the objects list."
-            ) % {
+            )
+            % {
                 "name": opts.verbose_name,
                 "obj": obj_display,
             },
             messages.SUCCESS,
-            )
+        )
 
         if self.has_change_permission(request, None):
             post_url = reverse(
                 "admin:%s_%s_changelist" % (opts.app_label, opts.model_name),
                 current_app=self.admin_site.name,
-                )
+            )
             preserved_filters = self.get_preserved_filters(request)
             post_url = add_preserved_filters(
                 {"preserved_filters": preserved_filters, "opts": opts}, post_url
@@ -96,6 +102,4 @@ class DataSourceAdmin(admin.ModelAdmin):
         return HttpResponseRedirect(post_url)
 
     def delete_queryset(self, request, queryset):
-        delete_datasource.delay(
-            serializers.serialize("json", [obj for obj in queryset])
-        )
+        delete_datasource.delay(serializers.serialize("json", list(queryset)))

--- a/dashboard_viewer/uploader/templates/admin/datasource/delete_selected_confirmation.html
+++ b/dashboard_viewer/uploader/templates/admin/datasource/delete_selected_confirmation.html
@@ -1,0 +1,58 @@
+{# Based on https://github.com/django/django/blob/2.2.17/django/contrib/admin/templates/admin/delete_selected_confirmation.html #}
+{# The only change was the action value on the action form #}
+
+{% extends "admin/base_site.html" %}
+{% load i18n l10n admin_urls static %}
+
+{% block extrahead %}
+    {{ block.super }}
+    {{ media }}
+    <script type="text/javascript" src="{% static 'admin/js/cancel.js' %}"></script>
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation delete-selected-confirmation{% endblock %}
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs">
+        <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+        &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+        &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+        &rsaquo; {% trans 'Delete multiple objects' %}
+    </div>
+{% endblock %}
+
+{% block content %}
+    {% if perms_lacking %}
+        <p>{% blocktrans %}Deleting the selected {{ objects_name }} would result in deleting related objects, but your account doesn't have permission to delete the following types of objects:{% endblocktrans %}</p>
+        <ul>
+            {% for obj in perms_lacking %}
+                <li>{{ obj }}</li>
+            {% endfor %}
+        </ul>
+    {% elif protected %}
+        <p>{% blocktrans %}Deleting the selected {{ objects_name }} would require deleting the following protected related objects:{% endblocktrans %}</p>
+        <ul>
+            {% for obj in protected %}
+                <li>{{ obj }}</li>
+            {% endfor %}
+        </ul>
+    {% else %}
+        <p>{% blocktrans %}Are you sure you want to delete the selected {{ objects_name }}? All of the following objects and their related items will be deleted:{% endblocktrans %}</p>
+        {% include "admin/includes/object_delete_summary.html" %}
+        <h2>{% trans "Objects" %}</h2>
+        {% for deletable_object in deletable_objects %}
+            <ul>{{ deletable_object|unordered_list }}</ul>
+        {% endfor %}
+        <form method="post">{% csrf_token %}
+            <div>
+                {% for obj in queryset %}
+                    <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk|unlocalize }}">
+                {% endfor %}
+                <input type="hidden" name="action" value="custom_delete_selected">
+                <input type="hidden" name="post" value="yes">
+                <input type="submit" value="{% trans "Yes, I'm sure" %}">
+                <a href="#" class="button cancel-link">{% trans "No, take me back" %}</a>
+            </div>
+        </form>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
Since the deletion of a task implies delete both achilles_results and achilles_resutls_archived records, the deletion through the admin console lead to a timeout.
On this PR this deletion process is sent to a background task.