### PR TITLE
fix/Avoid timeout on refresh of multiple mat views

### DIFF
--- a/dashboard_viewer/materialized_queries_manager/actions.py
+++ b/dashboard_viewer/materialized_queries_manager/actions.py
@@ -1,12 +1,11 @@
 from django.contrib import messages
-from django.core import serializers
 from django.utils.translation import gettext as _, gettext_lazy
 
 from .tasks import refresh_materialized_views_task
 
 
 def refresh_materialized_views_action(model_admin, request, queryset):
-    refresh_materialized_views_task.delay(serializers.serialize("json", queryset))
+    refresh_materialized_views_task.delay([obj.matviewname for obj in queryset])
 
     model_admin.message_user(
         request,

--- a/dashboard_viewer/materialized_queries_manager/tasks.py
+++ b/dashboard_viewer/materialized_queries_manager/tasks.py
@@ -131,6 +131,5 @@ def create_materialized_view(  # noqa
 
 
 @shared_task
-def refresh_materialized_views_task(query_set):
-    query_set = serializers.deserialize("json", query_set)
-    refresh(logger, query_set=[mat_query.object for mat_query in query_set])
+def refresh_materialized_views_task(names):
+    refresh(logger, query_set=MaterializedQuery.objects.filter(matviewname__in=names))


### PR DESCRIPTION
Previously both the name and the definition of all the materialized queries to refresh were sent as argument the background task. My guess is that this was too much data to serialize or send to Redis.
It now only sends their names and then the full objects are fetched on the background task.

## Motivation and Context
Browser Timeouts were happening whenever all the materialized queries were refreshed.
