### PR TITLE
fix/race condition on datasource update

### DIFF
--- a/dashboard_viewer/uploader/views.py
+++ b/dashboard_viewer/uploader/views.py
@@ -9,7 +9,6 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.html import format_html, mark_safe
 from django.views.decorators.clickjacking import xframe_options_exempt
 from rest_framework.response import Response
-from rest_framework.utils import model_meta
 from rest_framework.viewsets import GenericViewSet
 
 from materialized_queries_manager.tasks import refresh_materialized_views_task
@@ -307,9 +306,9 @@ class DataSourceUpdate(GenericViewSet):
         # here we get the query set with select_for_update so it lock updates on that record
         queryset = self.filter_queryset(self.get_queryset().select_for_update())
 
-        assert self.lookup_field and not self.lookup_url_kwarg, (
-            "Expected lookup_field to be defined and not lookup_url_kwarg."
-        )
+        assert (
+            self.lookup_field and not self.lookup_url_kwarg
+        ), "Expected lookup_field to be defined and not lookup_url_kwarg."
 
         filter_kwargs = {self.lookup_field: self.kwargs[self.lookup_field]}
         obj = get_object_or_404(queryset, **filter_kwargs)

--- a/dashboard_viewer/uploader/views.py
+++ b/dashboard_viewer/uploader/views.py
@@ -2,12 +2,14 @@ import itertools
 
 import constance
 from django.contrib import messages
+from django.db import router, transaction
 from django.forms import fields
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.html import format_html, mark_safe
 from django.views.decorators.clickjacking import xframe_options_exempt
 from rest_framework.response import Response
+from rest_framework.utils import model_meta
 from rest_framework.viewsets import GenericViewSet
 
 from materialized_queries_manager.tasks import refresh_materialized_views_task
@@ -301,11 +303,28 @@ class DataSourceUpdate(GenericViewSet):
     serializer_class = DataSourceSerializer
     queryset = DataSource.objects.all()
 
+    def get_object_for_patch(self):
+        # here we get the query set with select_for_update so it lock updates on that record
+        queryset = self.filter_queryset(self.get_queryset().select_for_update())
+
+        assert self.lookup_field and not self.lookup_url_kwarg, (
+            "Expected lookup_field to be defined and not lookup_url_kwarg."
+        )
+
+        filter_kwargs = {self.lookup_field: self.kwargs[self.lookup_field]}
+        obj = get_object_or_404(queryset, **filter_kwargs)
+
+        # May raise a permission denied
+        self.check_object_permissions(self.request, obj)
+
+        return obj
+
     def partial_update(self, request, *_, **__):
-        instance = self.get_object()
-        serializer = self.get_serializer(instance, data=request.data, partial=True)
-        serializer.is_valid(raise_exception=True)
-        serializer.save()
+        with transaction.atomic(using=router.db_for_write(DataSource)):
+            instance = self.get_object_for_patch()
+            serializer = self.get_serializer(instance, data=request.data, partial=True)
+            serializer.is_valid(raise_exception=True)
+            serializer.save()
 
         refresh_materialized_views_task.delay([obj.matviewname for obj in MaterializedQuery.objects.all()])
 


### PR DESCRIPTION
This is a known issue/caveat of django-rest-framework: https://github.com/encode/django-rest-framework/issues/5897.

This PR applies the necessary changes so no race conditions happen with consecutive requests being sent from montra.
The solution/approach that I used to solve, was to use select_for_update method, which locks a record until changes are committed.

Note: github actions errors addressed on #243