### PR TITLE
fix/add script to fix date formats

### DIFF
--- a/dashboard_viewer/utils/fix_dates.py
+++ b/dashboard_viewer/utils/fix_dates.py
@@ -1,0 +1,98 @@
+import datetime
+import re
+
+from django.db import transaction
+
+from uploader.models import AchillesResults
+
+MONTHS = dict(
+    map(
+        lambda t: (t[1], f"{t[0] + 1:02}"),
+        enumerate(("JAN", "FEV", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC")),
+    )
+)
+
+with_month = re.compile(r"(\d{2})-([A-Z]{3})-(\d{2})")  # 02-MAY-2020
+def with_month_extractor(match: re.Match):
+    day, month, year = match.groups()
+    return f"20{year}", MONTHS[month], day
+
+with_hiphen = re.compile(r"(\d{4})-(\d{2})-(\d{2})")  # 2020-12-02
+def with_hiphen_extractor(match: re.Match):
+    return match.groups()
+
+no_hiphen = re.compile(r"(\d{4})(\d{2})(\d{2})")  # 20201202
+no_hiphen_extractor = with_hiphen_extractor
+
+no_hiphen_float = re.compile(r"(\d{4})(\d{2})(\d{2})\.\d")  # 20201202.0
+no_hiphen_float_extractor = with_hiphen_extractor
+
+with_slash_one_digit = re.compile(r"(\d{1,2})/(\d{1,2})/(\d{4})")  # 1/31/2020 or 12/1/2020 or 1/1/2020 or 12/31/2020
+def with_slash_one_digit_extractor(match: re.Match):
+    month, day, year = match.groups()
+    return year, f"{int(month):02}", f"{int(day):02}"
+
+with_slash_two_digits = re.compile(r"(\d{2})/(\d{2})/(\d{2,4})")  # 31/01/20 or 31/01/2020
+def with_slash_two_digits_extractor(match: re.Match):
+    day, month, year = match.groups()
+    return ("" if len(year) == 4 else "20") + year, month, day
+
+
+PATTERNS = (
+    (with_month, with_month_extractor),
+    (with_hiphen, with_hiphen_extractor),
+    (no_hiphen, no_hiphen_extractor),
+    (no_hiphen_float, no_hiphen_float_extractor),
+    (with_slash_two_digits, with_slash_two_digits_extractor),  # try first with two digits then with one
+    (with_slash_one_digit, with_slash_one_digit_extractor),
+)
+
+
+def _convert_value(valid_pattern: re.Pattern, value: str):
+    for pattern, extractor in PATTERNS:
+        if pattern == valid_pattern:
+            continue
+        match = pattern.fullmatch(value)
+        if match:
+            date_tuple = extractor(match)
+            try:
+                datetime.date(*map(int, date_tuple))
+            except ValueError:
+                continue
+            return date_tuple
+    if valid_pattern.fullmatch(value):
+        return None
+    #print(f"unexpected date format -{value}-")
+    #return None
+    raise Exception(f"unexpected date format -{value}-")
+
+
+@transaction.atomic
+def apply_changes():
+    # fix generation_date
+    for ar in AchillesResults.objects.filter(analysis_id=0):
+        #upload = ar.data_source.uploadhistory_set.latest()
+        #print("upload", upload.pk)
+        if ar.stratum_3 and (new_date := _convert_value(no_hiphen, ar.stratum_3)) is not None:
+            year, month, day = new_date
+            #old = ar.stratum_3
+            ar.stratum_3 = f"{year}{month}{day}"
+            #print("from", old, "to", ar.stratum_3)
+            ar.save()
+    for ar in AchillesResults.objects.filter(analysis_id=5000):
+        #upload = ar.data_source.uploadhistory_set.latest()
+        #print("upload", upload.pk)
+        # fix source release date
+        if ar.stratum_2 and (new_date := _convert_value(with_hiphen, ar.stratum_2)) is not None:
+            year, month, day = new_date
+            #old = ar.stratum_2
+            ar.stratum_2 = f"{year}-{month}-{day}"
+            #print("source release from", old, "to", ar.stratum_2)
+            ar.save()
+        # fix cdm release date
+        if ar.stratum_3 and (new_date := _convert_value(with_hiphen, ar.stratum_3)) is not None:
+            year, month, day = new_date
+            #old = ar.stratum_3
+            ar.stratum_3 = f"{year}-{month}-{day}"
+            #print("cdm release from", old, "to", ar.stratum_3)
+            ar.save()

--- a/dashboard_viewer/utils/fix_dates.py
+++ b/dashboard_viewer/utils/fix_dates.py
@@ -112,7 +112,7 @@ def apply_changes():
         ):
             year, month, day = new_date
             # old = ar.stratum_3
-            ar.stratum_3 = f"{year}{month}{day}"
+            ar.stratum_3 = f"{year}-{month}-{day}"
             # print("from", old, "to", ar.stratum_3)
             ar.save()
     for ar in AchillesResults.objects.filter(analysis_id=5000):

--- a/dashboard_viewer/utils/fix_dates.py
+++ b/dashboard_viewer/utils/fix_dates.py
@@ -8,18 +8,39 @@ from uploader.models import AchillesResults
 MONTHS = dict(
     map(
         lambda t: (t[1], f"{t[0] + 1:02}"),
-        enumerate(("JAN", "FEV", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC")),
+        enumerate(
+            (
+                "JAN",
+                "FEV",
+                "MAR",
+                "APR",
+                "MAY",
+                "JUN",
+                "JUL",
+                "AUG",
+                "SEP",
+                "OCT",
+                "NOV",
+                "DEC",
+            )
+        ),
     )
 )
 
 with_month = re.compile(r"(\d{2})-([A-Z]{3})-(\d{2})")  # 02-MAY-2020
+
+
 def with_month_extractor(match: re.Match):
     day, month, year = match.groups()
     return f"20{year}", MONTHS[month], day
 
+
 with_hiphen = re.compile(r"(\d{4})-(\d{2})-(\d{2})")  # 2020-12-02
+
+
 def with_hiphen_extractor(match: re.Match):
     return match.groups()
+
 
 no_hiphen = re.compile(r"(\d{4})(\d{2})(\d{2})")  # 20201202
 no_hiphen_extractor = with_hiphen_extractor
@@ -27,12 +48,21 @@ no_hiphen_extractor = with_hiphen_extractor
 no_hiphen_float = re.compile(r"(\d{4})(\d{2})(\d{2})\.\d")  # 20201202.0
 no_hiphen_float_extractor = with_hiphen_extractor
 
-with_slash_one_digit = re.compile(r"(\d{1,2})/(\d{1,2})/(\d{4})")  # 1/31/2020 or 12/1/2020 or 1/1/2020 or 12/31/2020
+with_slash_one_digit = re.compile(
+    r"(\d{1,2})/(\d{1,2})/(\d{4})"
+)  # 1/31/2020 or 12/1/2020 or 1/1/2020 or 12/31/2020
+
+
 def with_slash_one_digit_extractor(match: re.Match):
     month, day, year = match.groups()
     return year, f"{int(month):02}", f"{int(day):02}"
 
-with_slash_two_digits = re.compile(r"(\d{2})/(\d{2})/(\d{2,4})")  # 31/01/20 or 31/01/2020
+
+with_slash_two_digits = re.compile(
+    r"(\d{2})/(\d{2})/(\d{2,4})"
+)  # 31/01/20 or 31/01/2020
+
+
 def with_slash_two_digits_extractor(match: re.Match):
     day, month, year = match.groups()
     return ("" if len(year) == 4 else "20") + year, month, day
@@ -43,7 +73,10 @@ PATTERNS = (
     (with_hiphen, with_hiphen_extractor),
     (no_hiphen, no_hiphen_extractor),
     (no_hiphen_float, no_hiphen_float_extractor),
-    (with_slash_two_digits, with_slash_two_digits_extractor),  # try first with two digits then with one
+    (
+        with_slash_two_digits,
+        with_slash_two_digits_extractor,
+    ),  # try first with two digits then with one
     (with_slash_one_digit, with_slash_one_digit_extractor),
 )
 
@@ -62,8 +95,8 @@ def _convert_value(valid_pattern: re.Pattern, value: str):
             return date_tuple
     if valid_pattern.fullmatch(value):
         return None
-    #print(f"unexpected date format -{value}-")
-    #return None
+    # print(f"unexpected date format -{value}-")
+    # return None
     raise Exception(f"unexpected date format -{value}-")
 
 
@@ -71,28 +104,37 @@ def _convert_value(valid_pattern: re.Pattern, value: str):
 def apply_changes():
     # fix generation_date
     for ar in AchillesResults.objects.filter(analysis_id=0):
-        #upload = ar.data_source.uploadhistory_set.latest()
-        #print("upload", upload.pk)
-        if ar.stratum_3 and (new_date := _convert_value(no_hiphen, ar.stratum_3)) is not None:
+        # upload = ar.data_source.uploadhistory_set.latest()
+        # print("upload", upload.pk)
+        if (
+            ar.stratum_3
+            and (new_date := _convert_value(no_hiphen, ar.stratum_3)) is not None
+        ):
             year, month, day = new_date
-            #old = ar.stratum_3
+            # old = ar.stratum_3
             ar.stratum_3 = f"{year}{month}{day}"
-            #print("from", old, "to", ar.stratum_3)
+            # print("from", old, "to", ar.stratum_3)
             ar.save()
     for ar in AchillesResults.objects.filter(analysis_id=5000):
-        #upload = ar.data_source.uploadhistory_set.latest()
-        #print("upload", upload.pk)
+        # upload = ar.data_source.uploadhistory_set.latest()
+        # print("upload", upload.pk)
         # fix source release date
-        if ar.stratum_2 and (new_date := _convert_value(with_hiphen, ar.stratum_2)) is not None:
+        if (
+            ar.stratum_2
+            and (new_date := _convert_value(with_hiphen, ar.stratum_2)) is not None
+        ):
             year, month, day = new_date
-            #old = ar.stratum_2
+            # old = ar.stratum_2
             ar.stratum_2 = f"{year}-{month}-{day}"
-            #print("source release from", old, "to", ar.stratum_2)
+            # print("source release from", old, "to", ar.stratum_2)
             ar.save()
         # fix cdm release date
-        if ar.stratum_3 and (new_date := _convert_value(with_hiphen, ar.stratum_3)) is not None:
+        if (
+            ar.stratum_3
+            and (new_date := _convert_value(with_hiphen, ar.stratum_3)) is not None
+        ):
             year, month, day = new_date
-            #old = ar.stratum_3
+            # old = ar.stratum_3
             ar.stratum_3 = f"{year}-{month}-{day}"
-            #print("cdm release from", old, "to", ar.stratum_3)
+            # print("cdm release from", old, "to", ar.stratum_3)
             ar.save()

--- a/dashboard_viewer/utils/fix_dates.py
+++ b/dashboard_viewer/utils/fix_dates.py
@@ -108,7 +108,7 @@ def apply_changes():
         # print("upload", upload.pk)
         if (
             ar.stratum_3
-            and (new_date := _convert_value(no_hiphen, ar.stratum_3)) is not None
+            and (new_date := _convert_value(with_hiphen, ar.stratum_3)) is not None
         ):
             year, month, day = new_date
             # old = ar.stratum_3

--- a/dashboard_viewer/utils/get_uploads_information.py
+++ b/dashboard_viewer/utils/get_uploads_information.py
@@ -1,0 +1,8 @@
+from uploader.models import DataSource, UploadHistory
+for db in DataSource.objects.all():
+    try:
+        last_upload = db.uploadhistory_set.latest()
+    except UploadHistory.DoesNotExist:
+        print("{},{},{}".format(db.acronym, db.name, db.hash))
+    else:
+        print("{},{},{},{},{}".format(db.acronym, db.name, db.hash, last_upload.upload_date, last_upload.generation_date))

--- a/dashboard_viewer/utils/get_uploads_information.py
+++ b/dashboard_viewer/utils/get_uploads_information.py
@@ -1,8 +1,10 @@
 from uploader.models import DataSource, UploadHistory
+
 for db in DataSource.objects.all():
+    print(f"{db.acronym},{db.name},{db.hash}", end="")
     try:
         last_upload = db.uploadhistory_set.latest()
     except UploadHistory.DoesNotExist:
-        print("{},{},{}".format(db.acronym, db.name, db.hash))
+        print()
     else:
-        print("{},{},{},{},{}".format(db.acronym, db.name, db.hash, last_upload.upload_date, last_upload.generation_date))
+        print(f",{last_upload.upload_date},{last_upload.generation_date}")


### PR DESCRIPTION
Closes #231

## Do we really need this?
As long as date formats are not corrected in CatalogueExport, this script will still be required to convert all dates to a common format, unless such process is done manually.

## Usage
1. Enter inside the dashboard container
2. 
   ```sh
   $ python manage.py shell
   ```
3. ```py
   from utils.fix_dates import apply_changes
   apply_changes()
   ```

Note: github actions errors addressed on #243