### PR TITLE
Fix/logging and default secret key

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -86,6 +86,4 @@ jobs:
         pip install --upgrade pip
         pip install -r requirements-dev/requirements-prospector.txt -r dashboard_viewer/requirements.txt
     - name: prospector
-      run: |
-        export $(grep -v '^#' tests/.env | xargs -d '\n')
-        DJANGO_SETTINGS_MODULE=dashboard_viewer.settings prospector dashboard_viewer
+      run: DJANGO_SETTINGS_MODULE=dashboard_viewer.settings prospector dashboard_viewer

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # documentation temporary files
 docs/src/_book
 
-# dashboard_viewer django app ERRORs logs
-logs
-
 # custom file created at docker/superset
 docker-init.sh
 

--- a/dashboard_viewer/dashboard_viewer/settings.py
+++ b/dashboard_viewer/dashboard_viewer/settings.py
@@ -9,7 +9,7 @@ https://docs.djangoproject.com/en/2.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.2/ref/settings/
 """
-
+import logging
 import os
 from distutils.util import strtobool
 
@@ -24,42 +24,42 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ["SECRET_KEY"]
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DASHBOARD_VIEWER_ENV", "development") == "development"
 
 
-_LOGS_DIR = os.path.join(BASE_DIR, "logs")
-if not os.path.exists(_LOGS_DIR):
-    os.makedirs(_LOGS_DIR, exist_ok=True)
-elif not os.path.isdir(_LOGS_DIR):
-    raise TypeError('file "logs" is not a directory.')
-
 LOGGING = {
     "version": 1,
-    "filters": {
-        "require_debug_true": {
-            "()": "django.utils.log.RequireDebugTrue",
+    "disable_existing_loggers": False,
+    "formatters": {
+        "custom": {
+            "format": "%(asctime)s %(levelname)s %(name)s:%(lineno)s %(msg)s",
         },
     },
     "handlers": {
-        "file": {
-            "level": "ERROR",
-            "filters": ["require_debug_true"],
-            "class": "logging.FileHandler",
-            "filename": os.path.join(_LOGS_DIR, "errors.log"),
-        }
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "custom",
+        },
     },
     "loggers": {
-        "django": {
-            "handlers": ["file"],
-            "level": "ERROR",
-            "propagate": True,
+        "root": {
+            "handlers": ["console"],
+            "level": "DEBUG" if DEBUG else "INFO",
         },
     },
 }
+
+
+_DEFAULT_SECRET_KEY = "CHANGE_ME"  # noqa
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = os.environ.get("SECRET_KEY", _DEFAULT_SECRET_KEY)
+if not DEBUG and SECRET_KEY == _DEFAULT_SECRET_KEY:
+    logging.getLogger(__name__).warning(
+        "Using the default secret key. If this is a production environment please change it.",
+    )
+
 
 ALLOWED_HOSTS = ["*"]
 

--- a/dashboard_viewer/dashboard_viewer/settings.py
+++ b/dashboard_viewer/dashboard_viewer/settings.py
@@ -33,7 +33,7 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "custom": {
-            "format": "%(asctime)s %(levelname)s %(name)s:%(lineno)s %(msg)s",
+            "format": "%(asctime)s %(levelname)s %(name)s:%(lineno)s %(message)s",
         },
     },
     "handlers": {

--- a/tox.ini
+++ b/tox.ini
@@ -28,9 +28,7 @@ deps =
 setenv =
     DJANGO_SETTINGS_MODULE=dashboard_viewer.settings
 commands =
-    bash -c "export $(grep -v '^#' tests/.env | xargs -d '\n') && prospector dashboard_viewer"
-whitelist_externals =
-    bash
+    prospector dashboard_viewer
 
 # tests
 [testenv:tests]


### PR DESCRIPTION
1. Our logging configurations were not showing HTTP 500. Configured in a way that keeps django's default loggers, which automatically log HTTP 500.
2. Add a default secret key so development and test environments are easier to set up. If the default key is used on production a warning is issued.

Note: github actions errors addressed on #243