### PR TITLE
new/Create a dashboard view

### DIFF
--- a/dashboard_viewer/dashboard_viewer/settings.py
+++ b/dashboard_viewer/dashboard_viewer/settings.py
@@ -10,8 +10,8 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
-from collections import OrderedDict
 import os
+from collections import OrderedDict
 from distutils.util import strtobool
 
 from constance.signals import config_updated
@@ -311,13 +311,25 @@ CONSTANCE_CONFIG = {
     ),
 }
 
-CONSTANCE_CONFIG_FIELDSETS = OrderedDict([
-    ("Application Attributes", ("APP_LOGO_IMAGE", "APP_LOGO_URL", "APP_TITLE")),
-    ("Uploader Texts", ("UPLOADER_EXECUTE_EXPORT_PACKAGE", "UPLOADER_UPLOAD", "UPLOADER_AUTO_UPDATE")),
-    ("Uploader Settings", ("UPLOADER_ALLOW_EDIT_DRAFT_STATUS",)),
-    ("Superset", ("SUPERSET_HOST", "DATABASE_DASHBOARD_IDENTIFIER", "DATABASE_FILTER_ID")),
-    ("Tabs (Deprecated)", ("TABS_LOGO_CONTAINER_CSS", "TABS_LOGO_IMG_CSS")),
-])
+CONSTANCE_CONFIG_FIELDSETS = OrderedDict(
+    [
+        ("Application Attributes", ("APP_LOGO_IMAGE", "APP_LOGO_URL", "APP_TITLE")),
+        (
+            "Uploader Texts",
+            (
+                "UPLOADER_EXECUTE_EXPORT_PACKAGE",
+                "UPLOADER_UPLOAD",
+                "UPLOADER_AUTO_UPDATE",
+            ),
+        ),
+        ("Uploader Settings", ("UPLOADER_ALLOW_EDIT_DRAFT_STATUS",)),
+        (
+            "Superset",
+            ("SUPERSET_HOST", "DATABASE_DASHBOARD_IDENTIFIER", "DATABASE_FILTER_ID"),
+        ),
+        ("Tabs (Deprecated)", ("TABS_LOGO_CONTAINER_CSS", "TABS_LOGO_IMG_CSS")),
+    ]
+)
 
 
 @receiver(config_updated)

--- a/dashboard_viewer/dashboard_viewer/settings.py
+++ b/dashboard_viewer/dashboard_viewer/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
+from collections import OrderedDict
 import os
 from distutils.util import strtobool
 
@@ -275,6 +276,21 @@ CONSTANCE_CONFIG = {
         "If a Data Source owner can change the draft status when editing its details",
         bool,
     ),
+    "SUPERSET_HOST": (
+        "https://superset.ehden.eu",
+        "Host of the target superset installation. Used to redirect to the dashboard of a database",
+        str,
+    ),
+    "DATABASE_DASHBOARD_IDENTIFIER": (
+        "database-level-dashboard",
+        "Identifier of the database dashboard on the Superset installation.",
+        str,
+    ),
+    "DATABASE_FILTER_ID": (
+        69,
+        "Id of the database filter present in the Database Dashboard",
+        int,
+    ),
     "TABS_LOGO_CONTAINER_CSS": (
         "padding: 5px 5px 5px 5px;\nheight: 100px;\nmargin-bottom: 10px;\n",
         "Css for the div container of the logo image",
@@ -294,6 +310,14 @@ CONSTANCE_CONFIG = {
         str,
     ),
 }
+
+CONSTANCE_CONFIG_FIELDSETS = OrderedDict([
+    ("Application Attributes", ("APP_LOGO_IMAGE", "APP_LOGO_URL", "APP_TITLE")),
+    ("Uploader Texts", ("UPLOADER_EXECUTE_EXPORT_PACKAGE", "UPLOADER_UPLOAD", "UPLOADER_AUTO_UPDATE")),
+    ("Uploader Settings", ("UPLOADER_ALLOW_EDIT_DRAFT_STATUS",)),
+    ("Superset", ("SUPERSET_HOST", "DATABASE_DASHBOARD_IDENTIFIER", "DATABASE_FILTER_ID")),
+    ("Tabs (Deprecated)", ("TABS_LOGO_CONTAINER_CSS", "TABS_LOGO_IMG_CSS")),
+])
 
 
 @receiver(config_updated)

--- a/dashboard_viewer/uploader/templates/no_uploads_dashboard.html
+++ b/dashboard_viewer/uploader/templates/no_uploads_dashboard.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Database Dashboard</title>
+
+  <style>
+    body {
+        text-align: center;
+    }
+    h4 {
+        line-height: 150%;
+        font-size: 18px;
+        font-family: Roboto, sans-serif;
+        font-weight: 500;
+    }
+  </style>
+</head>
+<body>
+  <h4>No data available: This database was not yet mapped into the CDM</h4>
+</body>
+</html>

--- a/dashboard_viewer/uploader/urls.py
+++ b/dashboard_viewer/uploader/urls.py
@@ -18,5 +18,9 @@ urlpatterns = [
         "<str:data_source>/upload/<int:upload_id>/status/", views.get_upload_task_status
     ),
     path("", views.create_data_source, name="create_data_source"),
-    path("<str:data_source>/dashboard/", views.data_source_dashboard, name="data_source_dashboard"),
+    path(
+        "<str:data_source>/dashboard/",
+        views.data_source_dashboard,
+        name="data_source_dashboard",
+    ),
 ]

--- a/dashboard_viewer/uploader/urls.py
+++ b/dashboard_viewer/uploader/urls.py
@@ -18,4 +18,5 @@ urlpatterns = [
         "<str:data_source>/upload/<int:upload_id>/status/", views.get_upload_task_status
     ),
     path("", views.create_data_source, name="create_data_source"),
+    path("<str:data_source>/dashboard/", views.data_source_dashboard, name="data_source_dashboard"),
 ]

--- a/dashboard_viewer/uploader/views.py
+++ b/dashboard_viewer/uploader/views.py
@@ -3,20 +3,20 @@ import itertools
 import constance
 from django.contrib import messages
 from django.forms import fields
-from django.http import JsonResponse
+from django.http import HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.html import format_html, mark_safe
 from django.views.decorators.clickjacking import xframe_options_exempt
 from rest_framework.response import Response
-from rest_framework.viewsets import GenericViewSet
+from rest_framework import viewsets
 
 from materialized_queries_manager.tasks import refresh_materialized_views_task
 from materialized_queries_manager.models import MaterializedQuery
 from .decorators import uploader_decorator
 from .forms import AchillesResultsForm, EditSourceForm, SourceForm
 from .models import Country, DataSource, PendingUpload, UploadHistory
-from .serializers import DataSourceSerializer
 from .tasks import upload_results_file
+from . import serializers
 
 PAGE_TITLE = "Dashboard Data Upload"
 
@@ -291,14 +291,32 @@ def edit_data_source(request, *_, **kwargs):
     )
 
 
-class DataSourceUpdate(GenericViewSet):
-    # since the edit and upload views have not authentication, also disable
+@uploader_decorator
+def data_source_dashboard(request, data_source):
+    try:
+        data_source = DataSource.objects.get(hash=data_source)
+    except DataSource.DoesNotExist:
+        return render(request, "no_uploads_dashboard.html")
+
+    if data_source.uploadhistory_set.exists():
+        config = constance.config
+        return HttpResponseRedirect(
+            f'{config.SUPERSET_HOST}/superset/dashboard/{config.DATABASE_DASHBOARD_IDENTIFIER}/'
+            '?standalone=1'
+            f'&preselect_filters={{"{config.DATABASE_FILTER_ID}":{{"acronym":["{data_source.acronym}"]}}}}'
+        )
+
+    return render(request, "no_uploads_dashboard.html")
+
+
+class DataSourceUpdate(viewsets.GenericViewSet):
+    # since the edit and upload views don't have authentication, also disable
     #  authentication from this
     authentication_classes = ()
     permission_classes = ()
 
     lookup_field = "hash"
-    serializer_class = DataSourceSerializer
+    serializer_class = serializers.DataSourceSerializer
     queryset = DataSource.objects.all()
 
     def partial_update(self, request, *_, **__):

--- a/dashboard_viewer/uploader/views.py
+++ b/dashboard_viewer/uploader/views.py
@@ -7,16 +7,16 @@ from django.http import HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.html import format_html, mark_safe
 from django.views.decorators.clickjacking import xframe_options_exempt
-from rest_framework.response import Response
 from rest_framework import viewsets
+from rest_framework.response import Response
 
 from materialized_queries_manager.tasks import refresh_materialized_views_task
 from materialized_queries_manager.models import MaterializedQuery
+from . import serializers
 from .decorators import uploader_decorator
 from .forms import AchillesResultsForm, EditSourceForm, SourceForm
 from .models import Country, DataSource, PendingUpload, UploadHistory
 from .tasks import upload_results_file
-from . import serializers
 
 PAGE_TITLE = "Dashboard Data Upload"
 
@@ -301,8 +301,8 @@ def data_source_dashboard(request, data_source):
     if data_source.uploadhistory_set.exists():
         config = constance.config
         return HttpResponseRedirect(
-            f'{config.SUPERSET_HOST}/superset/dashboard/{config.DATABASE_DASHBOARD_IDENTIFIER}/'
-            '?standalone=1'
+            f"{config.SUPERSET_HOST}/superset/dashboard/{config.DATABASE_DASHBOARD_IDENTIFIER}/"
+            "?standalone=1"
             f'&preselect_filters={{"{config.DATABASE_FILTER_ID}":{{"acronym":["{data_source.acronym}"]}}}}'
         )
 

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -43,7 +43,7 @@ x-dashboard-environment: &dashboard-environment
   REDIS_CELERY_DB: 1
   REDIS_CONSTANCE_DB: 2
   SECRET_KEY: ${DASHBOARD_VIEWER_SECRET_KEY}
-  DASHBOARD_VIEWER_ENV: ${INSTALLATION_ENV}
+  DASHBOARD_VIEWER_ENV: development
 
 version: "3.7"
 services:
@@ -110,11 +110,12 @@ services:
   dashboard_worker:
     build: *dashboard-build
     environment: *dashboard-environment
-    command: celery -A dashboard_viewer worker -Ofair -l INFO
+    command: celery -A dashboard_viewer worker -Ofair -l DEBUG
     restart: unless-stopped
     depends_on: *depends-on
     volumes:
       - ../dashboard_viewer/media:/app/media
+      - ../dashboard_viewer:/app
 
   dashboard:
     build: *dashboard-build


### PR DESCRIPTION
Fixes [bioinformatics-ua/montra-pvt#1967](https://github.com/bioinformatics-ua/montra-pvt/issues/1967)

When opening the database dashboard on the EHDEN Portal of a database that has not yet uploaded Achilles files into the platform the following will appear:
![image](https://user-images.githubusercontent.com/23409890/171648788-0cb554d6-8c81-46a0-abd1-3ede04afb155.png)

As the issue at the top mentions, a message should be presented instead of rendering the dashboard with "no results" on the charts.

## Implementation
Created a new view/endpoint `uploader/[db hash]/dashboard` which checks
1) if the data source exists
2) if it exists, checks if any upload was done.

If one of these conditions fails, the following simple page will render:
![image](https://user-images.githubusercontent.com/23409890/171650931-329dfb89-81ea-4d8b-869a-56e575906535.png)
else the view/endpoint will redirect to Superset's database dashboard

from `dashboards.ehden.eu/uploader/[db hash]/dashboard` to `https://superset.ehden.eu/superset/dashboard/database-level-dashboard/?standalone=1&preselect_filters=%7B%2269%22:%7B%22acronym%22:[%22DB_HASH%22]%7D%7D`.

I tested on an iframe and the redirect works nicely.

Note: github actions errors addressed on #243