### PR TITLE
imp/improve dashboard app gunicorn settings

### DIFF
--- a/dashboard_viewer/docker-entrypoint.sh
+++ b/dashboard_viewer/docker-entrypoint.sh
@@ -9,7 +9,7 @@ python manage.py compilescss
 python manage.py collectstatic --noinput --ignore="*.scss"
 
 if [ "${DASHBOARD_VIEWER_ENV}" = "production" ]; then
-    exec gunicorn dashboard_viewer.wsgi:application --bind 0.0.0.0:8000 --workers 5
+    exec gunicorn dashboard_viewer.wsgi:application --bind 0.0.0.0:8000 --workers 1 --worker-class gthread --thread 16
 else
     python manage.py runserver 0.0.0.0:8000
 fi


### PR DESCRIPTION
Previous settings: 5 workers each with 1 (default) thread
New settings: 1 worker each with 16 threads

I based myself on Superset's default settings (1 worker each with 20 threads). Since Superset's performance is more important than the dashboard app, I think we don't need to use 20 on the dashboard app and that's why I choose 16.