### PR TITLE
fix/avoid locks being unrecoverable

### DIFF
--- a/dashboard_viewer/dashboard_viewer/settings.py
+++ b/dashboard_viewer/dashboard_viewer/settings.py
@@ -208,6 +208,7 @@ REDIS_PORT = os.environ.get("REDIS_PORT", 6379)
 REDIS_CACHE_DB = os.environ.get("REDIS_CACHE_DB", 0)
 REDIS_CELERY_DB = os.environ.get("REDIS_CELERY_DB", 1)
 REDIS_CONSTANCE_DB = os.environ.get("REDIS_CONSTANCE_DB", 2)
+REDIS_CELERY_WORKERS_LOCKS_DB = os.environ.get("REDIS_CELERY_WORKERS_LOCKS_DB", 5)
 
 # Celery
 CELERY_BROKER_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_CELERY_DB}"
@@ -221,7 +222,14 @@ CACHES = {
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },
-    }
+    },
+    "workers_locks": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_CELERY_WORKERS_LOCKS_DB}",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
+    },
 }
 
 # Constance

--- a/dashboard_viewer/dashboard_viewer/settings.py
+++ b/dashboard_viewer/dashboard_viewer/settings.py
@@ -214,7 +214,13 @@ REDIS_CELERY_WORKERS_LOCKS_DB = os.environ.get("REDIS_CELERY_WORKERS_LOCKS_DB", 
 CELERY_BROKER_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_CELERY_DB}"
 CELERY_RESULT_BACKEND = "django-db"
 
+
 # Cache
+def locks_make_key(key, key_prefix, version):  # noqa
+    # since locks and stuff don't require versioning, ignore those fields when building the key store name
+    return key
+
+
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
@@ -226,6 +232,7 @@ CACHES = {
     "workers_locks": {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_CELERY_WORKERS_LOCKS_DB}",
+        "KEY_FUNCTION": locks_make_key,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },

--- a/dashboard_viewer/dashboard_viewer/settings.py
+++ b/dashboard_viewer/dashboard_viewer/settings.py
@@ -17,6 +17,7 @@ from distutils.util import strtobool
 from constance.signals import config_updated
 from django.core.validators import _lazy_re_compile, URLValidator
 from django.dispatch import receiver
+from sqlalchemy import create_engine
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -138,6 +139,13 @@ DATABASES = {
         "PASSWORD": os.environ.get("POSTGRES_ACHILLES_PASSWORD", "achilles"),
     },
 }
+
+ACHILLES_DB_SQLALCHEMY_ENGINE = create_engine(
+    "postgresql"
+    f"://{DATABASES['achilles']['USER']}:{DATABASES['achilles']['PASSWORD']}"
+    f"@{DATABASES['achilles']['HOST']}:{DATABASES['achilles']['PORT']}"
+    f"/{DATABASES['achilles']['NAME']}"
+)
 
 DATABASE_ROUTERS = ["dashboard_viewer.routers.AchillesRouter"]
 

--- a/dashboard_viewer/docker-entrypoint-worker.sh
+++ b/dashboard_viewer/docker-entrypoint-worker.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -x
+
+# clean locks
+echo '''from django.core.cache import caches
+cache = caches["workers_locks"]
+cache.delete_pattern("*")
+''' | python manage.py shell
+
+# remove all pending tasks
+celery -A dashboard_viewer purge -f
+
+# start unfinished pending uploads
+echo '''from django.db.models import Q
+from uploader.models import PendingUpload
+from uploader.tasks import upload_results_file
+for pu in PendingUpload.objects.filter(Q(status=PendingUpload.STATE_PENDING) | Q(status=PendingUpload.STATE_STARTED)):
+    print(f"Starting {pu.id}")
+    upload_results_file.delay(pu.id)
+''' | python manage.py shell
+
+# 4. start celery
+exec celery -A dashboard_viewer worker -Ofair -l INFO

--- a/dashboard_viewer/materialized_queries_manager/management/commands/refresh_mat_views.py
+++ b/dashboard_viewer/materialized_queries_manager/management/commands/refresh_mat_views.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.core.cache import cache
+from django.core.cache import caches
 from django.core.management.base import BaseCommand
 
 from materialized_queries_manager.utils import refresh
@@ -12,7 +12,7 @@ class Command(BaseCommand):
     help = "Closes the specified poll for voting"
 
     def handle(self, *args, **options):
-        if cache.get("celery_workers_updating") == 0:
+        if caches["workers_locks"].get("celery_workers_updating") == 0:
             refresh(logger)
             logger.info("Refresh done [command]")
         else:

--- a/dashboard_viewer/materialized_queries_manager/tasks.py
+++ b/dashboard_viewer/materialized_queries_manager/tasks.py
@@ -7,7 +7,7 @@ from celery.utils.log import get_task_logger
 from django.contrib.admin.models import ADDITION, CHANGE, LogEntry
 from django.contrib.admin.options import get_content_type_for_model
 from django.core import serializers
-from django.core.cache import cache
+from django.core.cache import caches
 from django.db import connections, ProgrammingError, router, transaction
 
 from materialized_queries_manager.models import MaterializedQuery
@@ -26,6 +26,8 @@ def create_materialized_view(  # noqa
         state=states.STARTED,
         meta=f"Processing Materialized Query {new_obj.matviewname}.",
     )
+
+    cache = caches["workers_locks"]
 
     with cache.lock("updating:materialized_view:worker:lock:" + new_obj.matviewname):
         worker_var = "updating:materialized_view:worker:" + new_obj.matviewname

--- a/dashboard_viewer/materialized_queries_manager/utils.py
+++ b/dashboard_viewer/materialized_queries_manager/utils.py
@@ -1,4 +1,4 @@
-from django.core.cache import cache
+from django.core.cache import caches
 from django.db import connections
 from redis_rw_lock import RWLock
 
@@ -6,6 +6,8 @@ from materialized_queries_manager.models import MaterializedQuery
 
 
 def refresh(logger, db_id=None, query_set=None):
+    cache = caches["workers_locks"]
+
     # Only one worker can update the materialized views at the same time -> same as -> only one thread
     #  can write to a file at the same time
     with RWLock(

--- a/dashboard_viewer/uploader/file_handler/updates.py
+++ b/dashboard_viewer/uploader/file_handler/updates.py
@@ -1,7 +1,5 @@
 import pandas
-from django.conf import settings
 from django.db import connections
-from sqlalchemy import create_engine
 
 from uploader.models import (
     AchillesResults,
@@ -12,7 +10,12 @@ from uploader.models import (
 )
 
 
-def update_achilles_results_data(logger, pending_upload: PendingUpload, file_metadata):
+def update_achilles_results_data(
+    logger,
+    pending_upload: PendingUpload,
+    file_metadata,
+    pandas_connection,
+):
     data_source_id = pending_upload.data_source.id
 
     logger.info(
@@ -44,26 +47,14 @@ def update_achilles_results_data(logger, pending_upload: PendingUpload, file_met
         pending_upload.id,
     )
 
-    engine = None
-    try:
-        engine = create_engine(
-            "postgresql"
-            f"://{settings.DATABASES['achilles']['USER']}:{settings.DATABASES['achilles']['PASSWORD']}"
-            f"@{settings.DATABASES['achilles']['HOST']}:{settings.DATABASES['achilles']['PORT']}"
-            f"/{settings.DATABASES['achilles']['NAME']}"
+    for chunk in reader:
+        chunk = chunk.assign(data_source_id=data_source_id)
+        chunk.to_sql(
+            AchillesResults._meta.db_table,
+            pandas_connection,
+            if_exists="append",
+            index=False,
         )
-
-        for chunk in reader:
-            chunk = chunk.assign(data_source_id=data_source_id)
-            chunk.to_sql(
-                AchillesResults._meta.db_table,
-                engine,
-                if_exists="append",
-                index=False,
-            )
-    finally:
-        if engine is not None:
-            engine.dispose()
 
 
 def move_achilles_results_records(

--- a/dashboard_viewer/uploader/tests.py
+++ b/dashboard_viewer/uploader/tests.py
@@ -2,6 +2,7 @@ import io
 import logging
 
 import numpy
+from django.conf import settings
 from django.core.cache import caches
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings, tag, TestCase, TransactionTestCase
@@ -135,6 +136,7 @@ class UpdateAchillesResultsDataTestCase(TransactionTestCase):
             id=1,
             uploaded_file=self.file,
         )
+        self._pandas_connection = settings.ACHILLES_DB_SQLALCHEMY_ENGINE.connect()
 
     def setUp(self) -> None:
         self._pending_upload.data_source = DataSource.objects.get(acronym="test1")
@@ -145,6 +147,7 @@ class UpdateAchillesResultsDataTestCase(TransactionTestCase):
             self._logger,
             self._pending_upload,
             self.file_metadata,
+            self._pandas_connection,
         )
         UploadHistory.objects.create(
             data_source=DataSource.objects.get(acronym="test1")
@@ -161,7 +164,10 @@ class UpdateAchillesResultsDataTestCase(TransactionTestCase):
     def test_move_records_of_only_one_db(self):
         self._pending_upload.uploaded_file.seek(0)
         update_achilles_results_data(
-            self._logger, self._pending_upload, self.file_metadata
+            self._logger,
+            self._pending_upload,
+            self.file_metadata,
+            self._pandas_connection,
         )
         UploadHistory.objects.create(
             data_source=DataSource.objects.get(acronym="test1")
@@ -170,7 +176,10 @@ class UpdateAchillesResultsDataTestCase(TransactionTestCase):
         self._pending_upload.uploaded_file.seek(0)
         self._pending_upload.data_source = DataSource.objects.get(acronym="test2")
         update_achilles_results_data(
-            self._logger, self._pending_upload, self.file_metadata
+            self._logger,
+            self._pending_upload,
+            self.file_metadata,
+            self._pandas_connection,
         )
         UploadHistory.objects.create(
             data_source=DataSource.objects.get(acronym="test2")

--- a/dashboard_viewer/uploader/tests.py
+++ b/dashboard_viewer/uploader/tests.py
@@ -2,7 +2,7 @@ import io
 import logging
 
 import numpy
-from django.core.cache import cache
+from django.core.cache import caches
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings, tag, TestCase, TransactionTestCase
 
@@ -361,7 +361,7 @@ class UploadResultsFileTestCase(TransactionTestCase):
         self.assertRaises(
             PendingUpload.DoesNotExist, PendingUpload.objects.get, id=pending_upload_id
         )
-        self.assertEqual(0, cache.get("celery_workers_updating"))
+        self.assertEqual(0, caches["workers_locks"].get("celery_workers_updating"))
 
         try:
             UploadHistory.objects.get(pending_upload_id=pending_upload_id)

--- a/dashboard_viewer/uploader/tests.py
+++ b/dashboard_viewer/uploader/tests.py
@@ -138,14 +138,23 @@ class UpdateAchillesResultsDataTestCase(TransactionTestCase):
             uploaded_file=self.file,
         )
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
         # we can use the variable settings.ACHILLES_DB_SQLALCHEMY_ENGINE because that won't use
         #  the achilles test database (test_achilles)
-        self._pandas_connection_engine = create_engine(  # we can't use settings
-           "postgresql"
-           f"://{settings.DATABASES['achilles']['USER']}:{settings.DATABASES['achilles']['PASSWORD']}"
-           f"@{settings.DATABASES['achilles']['HOST']}:{settings.DATABASES['achilles']['PORT']}"
-           f"/test_{settings.DATABASES['achilles']['NAME']}"
+        cls._pandas_connection_engine = create_engine(
+            "postgresql"
+            f"://{settings.DATABASES['achilles']['USER']}:{settings.DATABASES['achilles']['PASSWORD']}"
+            f"@{settings.DATABASES['achilles']['HOST']}:{settings.DATABASES['achilles']['PORT']}"
+            f"/{settings.DATABASES['achilles']['NAME']}"
         )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._pandas_connection_engine.dispose()
+        super().tearDownClass()
 
     def setUp(self) -> None:
         self._pending_upload.data_source = DataSource.objects.get(acronym="test1")

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -43,6 +43,7 @@ x-dashboard-environment: &dashboard-environment
   REDIS_CACHE_DB: 0
   REDIS_CELERY_DB: 1
   REDIS_CONSTANCE_DB: 2
+  REDIS_CELERY_WORKERS_LOCKS_DB: 5
   SECRET_KEY: ${DASHBOARD_VIEWER_SECRET_KEY}
   DASHBOARD_VIEWER_ENV: development
 
@@ -111,7 +112,7 @@ services:
   dashboard_worker:
     build: *dashboard-build
     environment: *dashboard-environment
-    command: celery -A dashboard_viewer worker -Ofair -l DEBUG
+    command: /app/docker-entrypoint-worker.sh
     restart: unless-stopped
     depends_on: *depends-on
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -39,6 +39,7 @@ x-dashboard-environment: &dashboard-environment
   REDIS_CACHE_DB: 0
   REDIS_CELERY_DB: 1
   REDIS_CONSTANCE_DB: 2
+  REDIS_CELERY_WORKERS_LOCKS_DB: 5
   SECRET_KEY: ${DASHBOARD_VIEWER_SECRET_KEY}
   DASHBOARD_VIEWER_ENV: ${INSTALLATION_ENV}
   SINGLE_APPLICATION_MODE: ${SINGLE_APPLICATION_MODE}
@@ -122,7 +123,7 @@ services:
   dashboard_worker:
     image: ehdenavr/networkdashboards
     environment: *dashboard-environment
-    command: celery -A dashboard_viewer worker -Ofair -l INFO
+    command: /app/docker-entrypoint-worker.sh
     restart: unless-stopped
     depends_on: *depends-on
     volumes:


### PR DESCRIPTION
If we performed a deployment upgrade while some celery tasks were executing, some redis locks would be unrecoverable.
With this PR:
1. created a separate redis db for locks.
2. when the dashboard worker starts:
   1. clears all locks
   2. starts tasks for all pending uploads that might have been interrupted. Since those execute operations over the database on a transaction, we can just restart the upload process because the previous progress was discarded.

Some other improvements that could be implemented: if there are several uploads pending, to the same database, only resume the most recent one and cancel the others.