### PR TITLE
Fix/prevent same data uploads

### DIFF
--- a/dashboard_viewer/uploader/file_handler/checks.py
+++ b/dashboard_viewer/uploader/file_handler/checks.py
@@ -1,15 +1,12 @@
 import csv
+import hashlib
 import io
+import os
 
 import numpy
 import pandas
 
-import hashlib
-import os
-from uploader.models import (
-    DataSource,
-    UploadHistory,
-)
+from uploader.models import DataSource, UploadHistory
 
 from django.conf import settings
 
@@ -37,8 +34,10 @@ class DuplicatedMetadataRow(FileChecksException):
 class MissingFieldValue(FileChecksException):
     pass
 
+
 class EqualFileAlreadyUploaded(FileChecksException):
     pass
+
 
 def _generate_file_reader(uploaded_file):
     """
@@ -276,7 +275,7 @@ def check_for_duplicated_files(uploaded_file, data_source_id):
 
         data_source_hash = DataSource.objects.filter(id=data_source_id).values_list('hash', flat=True).first()
         
-        if data_source_hash != None:
+        if data_source_hash is not None:
 
             # Go to the path where sucess filea are stored 
 
@@ -289,7 +288,7 @@ def check_for_duplicated_files(uploaded_file, data_source_id):
                     try: 
                         checksum_previous = hashlib.sha256(previous_upload_file.read()).hexdigest()
 
-                    except:
+                    except IOError:
                         
                         checksum_previous = None
 
@@ -298,16 +297,16 @@ def check_for_duplicated_files(uploaded_file, data_source_id):
                     try:
                         checksum_new = hashlib.sha256(new_upload_file.read()).hexdigest()
 
-                    except:
+                    except IOError:
                         
                         checksum_new = None
         
-                if (checksum_previous != None and checksum_new != None and checksum_previous == checksum_new):
+                if (checksum_previous is not None and checksum_new is not None and checksum_previous == checksum_new):
 
                     raise EqualFileAlreadyUploaded("File is already in the database")
 
     except UploadHistory.DoesNotExist:
-            pass
+        pass
 
     
     #### Added For Checksum ##########################

--- a/dashboard_viewer/uploader/file_handler/checks.py
+++ b/dashboard_viewer/uploader/file_handler/checks.py
@@ -4,6 +4,15 @@ import io
 import numpy
 import pandas
 
+import hashlib
+import os
+from uploader.models import (
+    DataSource,
+    UploadHistory,
+)
+
+from django.conf import settings
+
 
 class FileChecksException(Exception):
     pass
@@ -28,6 +37,8 @@ class DuplicatedMetadataRow(FileChecksException):
 class MissingFieldValue(FileChecksException):
     pass
 
+class EqualFileAlreadyUploaded(FileChecksException):
+    pass
 
 def _generate_file_reader(uploaded_file):
     """
@@ -251,3 +262,52 @@ def _get_upload_attr(analysis, stratum):
     if pandas.isna(value):
         return None
     return value
+
+
+def check_for_duplicated_files(uploaded_file, data_source_id):
+
+    #### Added For Checksum ##########################
+
+    try:
+        
+        # Upload History only stores the succesded files 
+
+        pd = UploadHistory.objects.filter(data_source_id=data_source_id).latest()
+
+        data_source_hash = DataSource.objects.filter(id=data_source_id).values_list('hash', flat=True).first()
+        
+        if data_source_hash != None:
+
+            # Go to the path where sucess filea are stored 
+
+            latest_file_path = os.path.join(settings.MEDIA_ROOT, pd.uploaded_file.path)
+
+            if os.path.exists(latest_file_path) and os.path.exists(uploaded_file.path):
+
+                with open(latest_file_path, "rb") as previous_upload_file:
+                    
+                    try: 
+                        checksum_previous = hashlib.sha256(previous_upload_file.read()).hexdigest()
+
+                    except:
+                        
+                        checksum_previous = None
+
+                with open(uploaded_file.path, "rb") as new_upload_file:
+                    
+                    try:
+                        checksum_new = hashlib.sha256(new_upload_file.read()).hexdigest()
+
+                    except:
+                        
+                        checksum_new = None
+        
+                if (checksum_previous != None and checksum_new != None and checksum_previous == checksum_new):
+
+                    raise EqualFileAlreadyUploaded("File is already in the database")
+
+    except UploadHistory.DoesNotExist:
+            pass
+
+    
+    #### Added For Checksum ##########################

--- a/dashboard_viewer/uploader/tasks.py
+++ b/dashboard_viewer/uploader/tasks.py
@@ -6,7 +6,10 @@ from django.db import router, transaction
 from redis_rw_lock import RWLock
 
 from materialized_queries_manager.utils import refresh
-from .file_handler.checks import extract_data_from_uploaded_file, check_for_duplicated_files
+from .file_handler.checks import (
+    check_for_duplicated_files,
+    extract_data_from_uploaded_file,
+)
 from .file_handler.updates import update_achilles_results_data
 from .models import AchillesResults, PendingUpload, UploadHistory
 

--- a/dashboard_viewer/uploader/tasks.py
+++ b/dashboard_viewer/uploader/tasks.py
@@ -32,18 +32,15 @@ def upload_results_file(pending_upload_id: int):
     )
 
     try:
-
-        ### Added for checksum 
         # To prevent the database owner from uploading the same data to the datasource
 
-        logger.info("Verifying Checksum of the upload file with recent data [datasource %d, pending upload %d]", 
+        logger.info(
+            "Verifying Checksum of the upload file with recent data [datasource %d, pending upload %d]",
             data_source.id,
             pending_upload.id,
         )
 
         check_for_duplicated_files(pending_upload.uploaded_file, data_source.id)
-        
-        ##### 
 
         logger.info(
             "Checking file format and data [datasource %d, pending upload %d]",

--- a/dashboard_viewer/uploader/tests.py
+++ b/dashboard_viewer/uploader/tests.py
@@ -372,7 +372,6 @@ class UploadResultsFileTestCase(TransactionTestCase):
             )
 
     def test_invalid_file_due_to_checksum(self):
-
         ExtractDataFromUploadedFileTestCase.file_7.seek(0)
 
         pending_upload_1 = PendingUpload.objects.create(
@@ -383,7 +382,7 @@ class UploadResultsFileTestCase(TransactionTestCase):
         )
 
         upload_results_file.delay(pending_upload_1.id)
-        
+
         # Upload the second file, with equal data
 
         ExtractDataFromUploadedFileTestCase.file_7.seek(0)
@@ -404,9 +403,8 @@ class UploadResultsFileTestCase(TransactionTestCase):
             PendingUpload.objects.get(id=new_pending_upload.id).status,
             PendingUpload.STATE_FAILED,
         )
-    
-    def test_valid_file_checksum(self):
 
+    def test_valid_file_checksum(self):
         ExtractDataFromUploadedFileTestCase.file_7.seek(0)
 
         pending_upload_1 = PendingUpload.objects.create(
@@ -417,7 +415,7 @@ class UploadResultsFileTestCase(TransactionTestCase):
         )
 
         upload_results_file.delay(pending_upload_1.id)
-        
+
         # Upload the second file, with different data
 
         new_file = io.BytesIO(
@@ -431,21 +429,20 @@ class UploadResultsFileTestCase(TransactionTestCase):
 
         new_pending_upload = PendingUpload.objects.create(
             data_source=DataSource.objects.get(acronym="test1"),
-            uploaded_file=SimpleUploadedFile(
-                "dummy", new_file.read()
-            ),
+            uploaded_file=SimpleUploadedFile("dummy", new_file.read()),
         )
 
         try:
             upload_results_file.delay(new_pending_upload.id)
         except EqualFileAlreadyUploaded:
-            self.fail(
-                "File is already in database"
-            )
+            self.fail("File is already in database")
 
         self.assertRaises(
-            PendingUpload.DoesNotExist, PendingUpload.objects.get, id=new_pending_upload.id
+            PendingUpload.DoesNotExist,
+            PendingUpload.objects.get,
+            id=new_pending_upload.id,
         )
+
         self.assertEqual(0, cache.get("celery_workers_updating"))
 
         try:


### PR DESCRIPTION
Adds hash mechanism to prevent the user or database owner to upload the same data or the same file, equal to the one already in the database, in the dashboards uploader. 

## Description

This PR adds a new check mechanism when a file is uploaded, namely by verifying if the data or file uploaded
is equal to the stored data for the data source, by evaluating the hashed contents of the uploaded file and
the file previous uploaded to the database, if it exists. 
This new step was implemented to act before every other check, such as the metadata ones, which allows
that if the same file is uploaded, the processing can immediately terminate, with no need to
process the other checks, as the upload process will fail.
For now the message presented in the uploader page in the case of a duplicated file is "File is already
present in the database". 

## Related Issue

Fixes #260

## Motivation and Context

The upload of files into the Network Dashboards can become computationally intensive process, in the case of large data, especially due to the refresh of the materialized views that occurs after each upload to incorporate the new data
in the graphic representations. By preventing the dashboard owners to upload the same data and the same files,
we are potentially saving server resources. 

## How Has This Been Tested?

Unit Tests:
 - a first valid file is uploaded, followed by another upload with the same content, evaluating if the process of upload failed.  
 - a first valid file is uploaded, followed by another upload with different content, evaluating if there was no errors in the upload
process. 

Testing Environment:
- Setup of the docker-compose stack for tests (postgres and redis) with test dependencies (as defined [here](https://github.com/EHDEN/NetworkDashboards/tree/master/tests))

Affected areas of the code:
- The code added affects the areas related to the upload functionalities, as it is now the first check. 