### PR TITLE
Fix/message in views

### DIFF
--- a/dashboard_viewer/uploader/templates/still_processing_achilles.html
+++ b/dashboard_viewer/uploader/templates/still_processing_achilles.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Database Dashboard</title>
+
+  <style>
+    body {
+        text-align: center;
+    }
+    h4 {
+        line-height: 150%;
+        font-size: 18px;
+        font-family: Roboto, sans-serif;
+        font-weight: 500;
+    }
+  </style>
+</head>
+<body>
+  <h4>File uploaded is still being processed!</h4>
+</body>
+</html>

--- a/dashboard_viewer/uploader/views.py
+++ b/dashboard_viewer/uploader/views.py
@@ -308,6 +308,26 @@ def data_source_dashboard(request, data_source):
             f'&preselect_filters={{"{config.DATABASE_FILTER_ID}":{{"acronym":["{data_source.acronym}"]}}}}'
         )
 
+    # This way if there is at least one successfull upload it will redirect to the dashboards
+    # We could only check if the last upload for the data source was sucessfull 
+        # -> This will not show data but it can bring a more useful message since the new data may not be processed and the graphics will contain old data
+        # -> Perhaps this is the best option has the user will expect the new data to be published and may think the graphics already
+        # contain that information
+        
+    if not data_source.uploadhistory_set.exists():
+
+        # Check last pending upload for the data source, it may have started but not completed
+        try:
+            status_of_pd = PendingUpload.objects.filter(data_source_id= data_source.id).values_list('status', flat = True).latest('id')
+
+            if status_of_pd == 2:
+
+                return render(request, "still_processing_achilles.html")
+
+        except PendingUpload.DoesNotExist:
+
+            return render(request, "no_uploads_dashboard.html")
+
     return render(request, "no_uploads_dashboard.html")
 
 

--- a/dashboard_viewer/uploader/views.py
+++ b/dashboard_viewer/uploader/views.py
@@ -309,23 +309,24 @@ def data_source_dashboard(request, data_source):
         )
 
     # This way if there is at least one successfull upload it will redirect to the dashboards
-    # We could only check if the last upload for the data source was sucessfull 
-        # -> This will not show data but it can bring a more useful message since the new data may not be processed and the graphics will contain old data
-        # -> Perhaps this is the best option has the user will expect the new data to be published and may think the graphics already
-        # contain that information
-        
-    if not data_source.uploadhistory_set.exists():
+    # We could only check if the last upload for the data source was sucessfull
+    # -> This will not show data but it can bring a more useful message since the new data may not be processed and the graphics will contain old data
+    # -> Perhaps this is the best option has the user will expect the new data to be published and may think the graphics already
+    # contain that information
 
+    if not data_source.uploadhistory_set.exists():
         # Check last pending upload for the data source, it may have started but not completed
         try:
-            status_of_pd = PendingUpload.objects.filter(data_source_id= data_source.id).values_list('status', flat = True).latest('id')
+            status_of_pd = (
+                PendingUpload.objects.filter(data_source_id=data_source.id)
+                .values_list("status", flat=True)
+                .latest("id")
+            )
 
             if status_of_pd == 2:
-
                 return render(request, "still_processing_achilles.html")
 
         except PendingUpload.DoesNotExist:
-
             return render(request, "no_uploads_dashboard.html")
 
     return render(request, "no_uploads_dashboard.html")


### PR DESCRIPTION
Change misleading message in dashboard views ("uploader/db_hash/dashboard/") when a file is still being uploaded but has not yet finished. 

## Description
<!--- Describe your changes in detail -->
When a file is uploaded but has not yet finished (that is, an upload history record was still not created) the uploader views (endpoint "uploader/db_hash/dashboard/") gives the message 'No data available: This database was not yet mapped into the CDM', which is not accurate.
This PR changes this message displayed for these cases to 'File uploaded is still being processed', by looking into the pending uploads and search for the latest one for the given data source, verifying if it is in the started state. This verification only occurs if there is no upload history for the given database/datasource. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #261

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change addresses the problem of a misleading message that is given in the uploader views.
Currently, the process of uploading a file can take too much time, for the case of large amounts of data, as previous processing tasks can still be executing (namely the refresh of materialized views). Therefore, the user, expecting that the results are available after a certain period of time,  will be presented with the message "No data available: This database was not yet mapped into the CDM" in the endpoint "uploader/db_hash/dashboard/", which may be misleading as the user actually uploaded a file, but the full upload process has not finished, which may be related to the problem initially described. 
This PR, for the cases where an upload has started but not yet completed, changes the message presented to the user to "File uploaded is still being processed", which represents a more accurate message. 