### PR TITLE
Fix/prevent multiple concept ids of zero

### DIFF
--- a/dashboard_viewer/uploader/file_handler/checks.py
+++ b/dashboard_viewer/uploader/file_handler/checks.py
@@ -271,7 +271,7 @@ def extract_data_from_uploaded_file(uploaded_file):
 
                 if repeated_counts[analysis_id] > 1:
                     raise MutipleConceptIdsEqualToZeroSameAnalysis(
-                        f"Concept Id of 0 duplicated for the same analysis. Try (re)running the plugin "
+                        f"Field Stratum 1 with the value of 0 duplicated for the same analysis. Try (re)running the plugin "
                         "<a href='https://github.com/EHDEN/CatalogueExport'>CatalogueExport</a>"
                         " on your database. If you think this is an error, please contact the system administrator."
                     )

--- a/dashboard_viewer/uploader/file_handler/checks.py
+++ b/dashboard_viewer/uploader/file_handler/checks.py
@@ -38,10 +38,6 @@ class EqualFileAlreadyUploaded(FileChecksException):
     pass
 
 
-class MutipleConceptIdsEqualToZeroSameAnalysis(FileChecksException):
-    pass
-
-
 def _generate_file_reader(uploaded_file):
     """
     Receives a python file pointer and returns a pandas csv file reader, along with the columns
@@ -179,12 +175,6 @@ def extract_data_from_uploaded_file(uploaded_file):
 
     metadata = None
 
-    # To check for repeated concept ids equal to zero for the same analysis
-
-    repeated_counts = (
-        {}
-    )  # to store the counts of the concept_ids equal to zero for all chunks of the file being processed
-
     while True:
         try:
             chunk = next(file_reader)
@@ -239,42 +229,6 @@ def extract_data_from_uploaded_file(uploaded_file):
                 "<a href='https://github.com/EHDEN/CatalogueExport'>CatalogueExport</a>"
                 " on your database."
             )
-
-        # Verify for multiple concept ids equal to 0 on the same analysis
-
-        analysis_rows = chunk.loc[
-            (chunk["stratum_1"] == "0")
-            & (
-                chunk[
-                    chunk.columns.symmetric_difference(
-                        ["analysis_id", "stratum_1", "count_value"]
-                    )
-                ]
-                .isnull()
-                .all(axis=1)
-            )
-        ]
-
-        analysis = analysis_rows["analysis_id"].unique()
-
-        if analysis_rows.empty == False:
-            for analysis_id in analysis:
-                duplicate_counts = analysis_rows.loc[
-                    (analysis_rows["analysis_id"] == analysis_id)
-                ].shape[0]
-
-                if analysis_id in repeated_counts:
-                    repeated_counts[analysis_id] += duplicate_counts
-
-                else:
-                    repeated_counts[analysis_id] = duplicate_counts
-
-                if repeated_counts[analysis_id] > 1:
-                    raise MutipleConceptIdsEqualToZeroSameAnalysis(
-                        f"Field Stratum 1 with the value of 0 duplicated for the same analysis. Try (re)running the plugin "
-                        "<a href='https://github.com/EHDEN/CatalogueExport'>CatalogueExport</a>"
-                        " on your database. If you think this is an error, please contact the system administrator."
-                    )
 
     analysis_0 = metadata[metadata.analysis_id == 0]
     if analysis_0.empty:

--- a/dashboard_viewer/uploader/file_handler/updates.py
+++ b/dashboard_viewer/uploader/file_handler/updates.py
@@ -49,6 +49,9 @@ def update_achilles_results_data(
 
     for chunk in reader:
         chunk = chunk.assign(data_source_id=data_source_id)
+
+        chunk = chunk.loc[chunk["stratum_1"] != "0"]
+
         chunk.to_sql(
             AchillesResults._meta.db_table,
             pandas_connection,

--- a/dashboard_viewer/uploader/tests.py
+++ b/dashboard_viewer/uploader/tests.py
@@ -16,7 +16,9 @@ from .file_handler.checks import (
     InvalidFieldValue,
     InvalidFileFormat,
     MissingFieldValue,
+    MutipleConceptIdsEqualToZeroSameAnalysis,
 )
+
 from .file_handler.updates import update_achilles_results_data
 from .models import (
     AchillesResults,
@@ -474,11 +476,37 @@ class UploadResultsFileTestCase(TransactionTestCase):
             id=new_pending_upload.id,
         )
 
-        self.assertEqual(0, cache.get("celery_workers_updating"))
-
         try:
             UploadHistory.objects.get(pending_upload_id=new_pending_upload.id)
         except UploadHistory.DoesNotExist:
             self.fail(
                 "No upload history record with the associated pending upload id created"
             )
+
+    def test_file_with_multiple_concept_ids_equal_to_zero(self):
+        invalid_file = io.BytesIO(
+            bytes(
+                "analysis_id,stratum_1,stratum_2,stratum_3,stratum_4,stratum_5,count_value\n"
+                "0,,,,,,1000\n"
+                "1,,,,,,1000\n"
+                "401,0,,,,,1000\n"
+                "401,0,,,,,2000\n",
+                "utf8",
+            )
+        )
+        pending_upload = PendingUpload.objects.create(
+            data_source=DataSource.objects.get(acronym="test1"),
+            uploaded_file=SimpleUploadedFile("dummy", invalid_file.read()),
+        )
+
+        # Upload the file with multiple concept ids equal to zero
+
+        try:
+            upload_results_file.delay(pending_upload.id)
+        except MutipleConceptIdsEqualToZeroSameAnalysis:
+            pass
+
+        self.assertEqual(
+            PendingUpload.objects.get(id=pending_upload.id).status,
+            PendingUpload.STATE_FAILED,
+        )

--- a/dashboard_viewer/uploader/tests.py
+++ b/dashboard_viewer/uploader/tests.py
@@ -16,9 +16,7 @@ from .file_handler.checks import (
     InvalidFieldValue,
     InvalidFileFormat,
     MissingFieldValue,
-    MutipleConceptIdsEqualToZeroSameAnalysis,
 )
-
 from .file_handler.updates import update_achilles_results_data
 from .models import (
     AchillesResults,
@@ -482,31 +480,3 @@ class UploadResultsFileTestCase(TransactionTestCase):
             self.fail(
                 "No upload history record with the associated pending upload id created"
             )
-
-    def test_file_with_multiple_concept_ids_equal_to_zero(self):
-        invalid_file = io.BytesIO(
-            bytes(
-                "analysis_id,stratum_1,stratum_2,stratum_3,stratum_4,stratum_5,count_value\n"
-                "0,,,,,,1000\n"
-                "1,,,,,,1000\n"
-                "401,0,,,,,1000\n"
-                "401,0,,,,,2000\n",
-                "utf8",
-            )
-        )
-        pending_upload = PendingUpload.objects.create(
-            data_source=DataSource.objects.get(acronym="test1"),
-            uploaded_file=SimpleUploadedFile("dummy", invalid_file.read()),
-        )
-
-        # Upload the file with multiple concept ids equal to zero
-
-        try:
-            upload_results_file.delay(pending_upload.id)
-        except MutipleConceptIdsEqualToZeroSameAnalysis:
-            pass
-
-        self.assertEqual(
-            PendingUpload.objects.get(id=pending_upload.id).status,
-            PendingUpload.STATE_FAILED,
-        )


### PR DESCRIPTION
This PR adds a new check when a file is uploaded, verifying if there are repeated stratum_1 fields equal to zero for the same analysis.

## Description
A new verification is added when uploading a file that counts the occurrences of stratum_1 fields equal to zero for all the analysis. 

## Related Issue
Fixes #264

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It prevents the upload of files that contain multiple stratum_1 fields set to 0 for the same analysis, which does not present relevant information and occupies unnecessary resources in the system. 

## How Has This Been Tested?

Unit Tests:
an invalid uploaded file is uploaded, with two entries with the same analysis and stratum_1 fields defined to 0, evaluating if the process of upload failed.

Testing Environment:

Setup of the docker-compose stack for tests (postgres and redis) with test dependencies (as defined [here](https://github.com/EHDEN/NetworkDashboards/tree/master/tests))

Affected areas of the code:

The code added affects the areas related to the upload functionalities.
