### PR TITLE
Fix/prevent processing of records with the stratum1 of zero

### DIFF
--- a/dashboard_viewer/uploader/file_handler/updates.py
+++ b/dashboard_viewer/uploader/file_handler/updates.py
@@ -48,6 +48,7 @@ def update_achilles_results_data(
     )
 
     for chunk in reader:
+        chunk = chunk[chunk["stratum_1"].isin(["0"]) == False]
         chunk = chunk.assign(data_source_id=data_source_id)
         chunk.to_sql(
             AchillesResults._meta.db_table,

--- a/dashboard_viewer/uploader/tests.py
+++ b/dashboard_viewer/uploader/tests.py
@@ -2,6 +2,7 @@ import io
 import logging
 
 import numpy
+from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.core.cache import caches
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -27,6 +28,8 @@ from .models import (
     UploadHistory,
 )
 from .tasks import upload_results_file
+
+logger = get_task_logger(__name__)
 
 
 @tag("third-party-app")
@@ -213,6 +216,35 @@ class UpdateAchillesResultsDataTestCase(TransactionTestCase):
 
         self._pending_upload.data_source = DataSource.objects.get(acronym="test1")
         self._update_and_check(4, 2)
+
+    def test_processing_when_stratum1_is_zero(self):
+        new_file1 = io.BytesIO(
+            bytes(
+                "analysis_id,stratum_1,stratum_2,stratum_3,stratum_4,stratum_5,count_value\n"
+                "0,,5,0,,,2000\n"
+                "101,0,5,0,,,2000\n"
+                "5000,,1,,2,4,1001\n",
+                "utf8",
+            )
+        )
+
+        new_pending_upload = PendingUpload.objects.create(
+            data_source=DataSource.objects.get(acronym="test1"),
+            uploaded_file=SimpleUploadedFile("dummy", new_file1.read()),
+        )
+
+        update_achilles_results_data(
+            self._logger,
+            new_pending_upload,
+            self.file_metadata,
+            self._pandas_connection,
+        )
+        UploadHistory.objects.create(
+            data_source=DataSource.objects.get(acronym="test1")
+        )
+
+        self.assertEqual(2, AchillesResults.objects.count())
+        self.assertEqual(0, AchillesResults.objects.filter(stratum_1='0').count())
 
 
 class ExtractDataFromUploadedFileTestCase(TestCase):

--- a/dashboard_viewer/uploader/tests.py
+++ b/dashboard_viewer/uploader/tests.py
@@ -244,7 +244,7 @@ class UpdateAchillesResultsDataTestCase(TransactionTestCase):
         )
 
         self.assertEqual(2, AchillesResults.objects.count())
-        self.assertEqual(0, AchillesResults.objects.filter(stratum_1='0').count())
+        self.assertEqual(0, AchillesResults.objects.filter(stratum_1="0").count())
 
 
 class ExtractDataFromUploadedFileTestCase(TestCase):

--- a/dashboard_viewer/uploader/tests.py
+++ b/dashboard_viewer/uploader/tests.py
@@ -474,8 +474,6 @@ class UploadResultsFileTestCase(TransactionTestCase):
             id=new_pending_upload.id,
         )
 
-        self.assertEqual(0, cache.get("celery_workers_updating"))
-
         try:
             UploadHistory.objects.get(pending_upload_id=new_pending_upload.id)
         except UploadHistory.DoesNotExist:


### PR DESCRIPTION
This PR adds a processing mechanism that does not process records/lines of the file being uploaded in the cases where the field stratum_1 is 0.

## Description

Lines/Records with the stratum_1 set to zero are discarded by the system from the file being uploaded.

## Related Issue

Fixes #264

## Motivation and Context

It prevents the upload of rows of the file being uploaded that contain stratum_1 fields set to 0, since it does not present relevant information.

## How Has This Been Tested?

Unit Tests:

Upload of files, with the stratum_1 set to 0 in one record, verifying the number of records in the database is the one expected, and there is none with a stratum_1 of zero.

Testing Environment:

Setup of the docker-compose stack for tests (postgres and redis) with test dependencies (as defined [here](https://github.com/EHDEN/NetworkDashboards/tree/master/tests))

Affected areas of the code:

The code added affects the areas related to the upload functionalities.