### PR TITLE
Imp/validate uploads

### DIFF
--- a/dashboard_viewer/materialized_queries_manager/admin.py
+++ b/dashboard_viewer/materialized_queries_manager/admin.py
@@ -226,7 +226,7 @@ class MaterializedQueryAdmin(admin.ModelAdmin):
         """
         if hasattr(self, "background_task"):
             background_task_id = getattr(self, "background_task").id
-            try:
+            try:  # noqa
                 task_url = reverse(
                     f"admin:{TaskResult._meta.app_label}_{TaskResult._meta.model_name}_change",
                     args=(

--- a/dashboard_viewer/materialized_queries_manager/migrations/0001_initial.py
+++ b/dashboard_viewer/materialized_queries_manager/migrations/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/dashboard_viewer/materialized_queries_manager/tests.py
+++ b/dashboard_viewer/materialized_queries_manager/tests.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User  # noqa
 from django.core import serializers
 from django.test import Client, TestCase, TransactionTestCase
 from django_celery_results.models import TaskResult
@@ -42,7 +42,7 @@ class MaterializedQueryTestCase(TestCase):
     def test_single_delete(self):
         client = _login_admin(self)
         client.post(
-            "/admin/%s/%s/outlier/delete/"
+            "/admin/%s/%s/outlier/delete/"  # noqa
             % (MaterializedQuery._meta.app_label, MaterializedQuery._meta.model_name),
             data={"post": "yes"},
         )
@@ -54,7 +54,7 @@ class MaterializedQueryTestCase(TestCase):
     def test_multiple_delete(self):
         client = _login_admin(self)
         client.post(
-            "/admin/%s/%s/"
+            "/admin/%s/%s/"  # noqa
             % (MaterializedQuery._meta.app_label, MaterializedQuery._meta.model_name),
             data={
                 "post": "yes",
@@ -73,7 +73,7 @@ class MaterializedQueryTestCase(TestCase):
     def test_add_view(self, create_task):
         client = _login_admin(self)
         client.post(
-            "/admin/%s/%s/add/"
+            "/admin/%s/%s/add/"  # noqa
             % (MaterializedQuery._meta.app_label, MaterializedQuery._meta.model_name),
             data={"matviewname": "test", "definition": "SELECT"},
         )
@@ -97,7 +97,7 @@ class MaterializedQueryTestCase(TestCase):
         """
         client = _login_admin(self)
         client.post(
-            "/admin/%s/%s/outlier/change/"
+            "/admin/%s/%s/outlier/change/"  # noqa
             % (MaterializedQuery._meta.app_label, MaterializedQuery._meta.model_name),
             data={"matviewname": "outlier", "definition": "SELECT 2"},
         )
@@ -133,7 +133,7 @@ class CeleryTasksTestCase(TransactionTestCase):
         task.wait()
 
         self.assertEqual(3, MaterializedQuery.objects.count())
-        self.assertEquals(
+        self.assertEquals(  # noqa
             " SELECT 2;",
             MaterializedQuery.objects.get(matviewname="outlier").definition,
         )
@@ -158,7 +158,7 @@ class CeleryTasksTestCase(TransactionTestCase):
             in task_results.result
         )
         self.assertEqual(3, MaterializedQuery.objects.count())
-        self.assertEquals(
+        self.assertEquals(  # noqa
             " SELECT 1;",
             MaterializedQuery.objects.get(matviewname="outlier").definition,
         )
@@ -191,7 +191,7 @@ class CeleryTasksTestCase(TransactionTestCase):
             from django.db import connections  # noqa
 
             with connections["achilles"].cursor() as cursor:
-                cursor.execute(f"DROP MATERIALIZED VIEW IF EXISTS outlier2")
+                cursor.execute(f"DROP MATERIALIZED VIEW IF EXISTS outlier2")  # noqa
 
     def test_valid_create(self):
         task = create_materialized_view.delay(
@@ -219,7 +219,7 @@ class CeleryTasksTestCase(TransactionTestCase):
             from django.db import connections  # noqa
 
             with connections["achilles"].cursor() as cursor:
-                cursor.execute(f"DROP MATERIALIZED VIEW IF EXISTS outlier2")
+                cursor.execute(f"DROP MATERIALIZED VIEW IF EXISTS outlier2")  # noqa
 
     def test_invalid_create(self):
         task = create_materialized_view.delay(

--- a/dashboard_viewer/tabsManager/migrations/0001_initial.py
+++ b/dashboard_viewer/tabsManager/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/dashboard_viewer/tabsManager/migrations/0002_auto_20200214_1128.py
+++ b/dashboard_viewer/tabsManager/migrations/0002_auto_20200214_1128.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tabsManager", "0001_initial"),
     ]

--- a/dashboard_viewer/tabsManager/migrations/0002_auto_20200316_1946.py
+++ b/dashboard_viewer/tabsManager/migrations/0002_auto_20200316_1946.py
@@ -28,7 +28,6 @@ def associate_tab_and_button(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tabsManager", "0002_auto_20200214_1128"),
     ]

--- a/dashboard_viewer/tabsManager/migrations/0002_auto_20200316_1946.py
+++ b/dashboard_viewer/tabsManager/migrations/0002_auto_20200316_1946.py
@@ -4,7 +4,7 @@ import django.db.models.deletion
 from django.db import migrations, models
 
 
-def move_tabs_to_buttons(apps, schema_editor):
+def move_tabs_to_buttons(apps, schema_editor):  # noqa
     Button = apps.get_model("tabsManager", "Button")
     Tab = apps.get_model("tabsManager", "Tab")
 
@@ -17,7 +17,7 @@ def move_tabs_to_buttons(apps, schema_editor):
         ).save()
 
 
-def associate_tab_and_button(apps, schema_editor):
+def associate_tab_and_button(apps, schema_editor):  # noqa
     Button = apps.get_model("tabsManager", "Button")
     Tab = apps.get_model("tabsManager", "Tab")
 

--- a/dashboard_viewer/tabsManager/migrations/0003_logo.py
+++ b/dashboard_viewer/tabsManager/migrations/0003_logo.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tabsManager", "0002_auto_20200316_1946"),
     ]

--- a/dashboard_viewer/tabsManager/migrations/0003_logo.py
+++ b/dashboard_viewer/tabsManager/migrations/0003_logo.py
@@ -34,7 +34,7 @@ class Migration(migrations.Migration):
                     "imageCss",
                     models.TextField(
                         blank=True,
-                        default="background: #fff;\nobject-fit: contain;\nwidth: 90px;\nheight: 100%;\nborder-radius: 30px;\npadding: 0 5px 0 5px;\ntransition: width 400ms, height 400ms;\nposition: relative;\nz-index: 5;\n",
+                        default="background: #fff;\nobject-fit: contain;\nwidth: 90px;\nheight: 100%;\nborder-radius: 30px;\npadding: 0 5px 0 5px;\ntransition: width 400ms, height 400ms;\nposition: relative;\nz-index: 5;\n",  # noqa
                     ),
                 ),
                 (

--- a/dashboard_viewer/tabsManager/migrations/0004_auto_20200924_1729.py
+++ b/dashboard_viewer/tabsManager/migrations/0004_auto_20200924_1729.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tabsManager", "0003_logo"),
     ]

--- a/dashboard_viewer/tabsManager/migrations/0005_delete_logo.py
+++ b/dashboard_viewer/tabsManager/migrations/0005_delete_logo.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tabsManager", "0004_auto_20200924_1729"),
     ]

--- a/dashboard_viewer/uploader/file_handler/checks.py
+++ b/dashboard_viewer/uploader/file_handler/checks.py
@@ -98,7 +98,7 @@ def _generate_file_reader(uploaded_file):
 
     uploaded_file.seek(0)
 
-    try:
+    try:  # noqa
         file_reader = pandas.read_csv(
             uploaded_file,
             header=0,

--- a/dashboard_viewer/uploader/migrations/0001_initial.py
+++ b/dashboard_viewer/uploader/migrations/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/dashboard_viewer/uploader/migrations/0002_auto_20200519_1948.py
+++ b/dashboard_viewer/uploader/migrations/0002_auto_20200519_1948.py
@@ -3,7 +3,7 @@
 from django.db import migrations, models
 
 
-def fill_acronym(apps, schema_editor):
+def fill_acronym(apps, schema_editor):  # noqa
     DataSource = apps.get_model("uploader", "DataSource")
 
     for data_source in DataSource.objects.all():

--- a/dashboard_viewer/uploader/migrations/0002_auto_20200519_1948.py
+++ b/dashboard_viewer/uploader/migrations/0002_auto_20200519_1948.py
@@ -12,7 +12,6 @@ def fill_acronym(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("uploader", "0001_initial"),
     ]

--- a/dashboard_viewer/uploader/migrations/0002_auto_20200803_1352.py
+++ b/dashboard_viewer/uploader/migrations/0002_auto_20200803_1352.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("uploader", "0001_initial"),
     ]

--- a/dashboard_viewer/uploader/migrations/0003_merge_20200923_1703.py
+++ b/dashboard_viewer/uploader/migrations/0003_merge_20200923_1703.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("uploader", "0002_auto_20200803_1352"),
         ("uploader", "0002_auto_20200519_1948"),

--- a/dashboard_viewer/uploader/migrations/0004_auto_20201001_1037.py
+++ b/dashboard_viewer/uploader/migrations/0004_auto_20201001_1037.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("uploader", "0003_merge_20200923_1703"),
     ]

--- a/dashboard_viewer/uploader/migrations/0005_auto_20201002_1125.py
+++ b/dashboard_viewer/uploader/migrations/0005_auto_20201002_1125.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("uploader", "0004_auto_20201001_1037"),
     ]

--- a/dashboard_viewer/uploader/migrations/0006_auto_20201109_2152.py
+++ b/dashboard_viewer/uploader/migrations/0006_auto_20201109_2152.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("uploader", "0005_auto_20201002_1125"),
     ]

--- a/dashboard_viewer/uploader/migrations/0007_auto_20201212_2012.py
+++ b/dashboard_viewer/uploader/migrations/0007_auto_20201212_2012.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("uploader", "0006_auto_20201109_2152"),
     ]

--- a/dashboard_viewer/uploader/migrations/0008_auto_20201217_1425.py
+++ b/dashboard_viewer/uploader/migrations/0008_auto_20201217_1425.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("uploader", "0007_auto_20201212_2012"),
     ]

--- a/dashboard_viewer/uploader/migrations/0009_auto_20210112_1719.py
+++ b/dashboard_viewer/uploader/migrations/0009_auto_20210112_1719.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("uploader", "0008_auto_20201217_1425"),
     ]

--- a/dashboard_viewer/uploader/migrations/0010_auto_20210507_1500.py
+++ b/dashboard_viewer/uploader/migrations/0010_auto_20210507_1500.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.db import migrations, models
 
 
-def set_hash(apps, schema_editor):
+def set_hash(apps, schema_editor):  # noqa
     DataSource = apps.get_model("uploader", "DataSource")
     data_sources = DataSource.objects.all()
     if data_sources.exists():
@@ -18,7 +18,7 @@ def set_hash(apps, schema_editor):
         )
 
         try:
-            with open("acronym2hash_mappings.json") as mappings_file:
+            with open("acronym2hash_mappings.json") as mappings_file:  # noqa
                 mappings = json.load(mappings_file)
 
                 for data_source in data_sources:

--- a/dashboard_viewer/uploader/migrations/0011_country_alpha2.py
+++ b/dashboard_viewer/uploader/migrations/0011_country_alpha2.py
@@ -50,7 +50,6 @@ def fill_apha2(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("uploader", "0010_auto_20210507_1500"),
     ]

--- a/dashboard_viewer/uploader/migrations/0011_country_alpha2.py
+++ b/dashboard_viewer/uploader/migrations/0011_country_alpha2.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.db import migrations, models
 
 
-def fill_apha2(apps, schema_editor):
+def fill_apha2(apps, schema_editor):  # noqa
     changes = {
         "Aland Islands": "Åland Islands",
         "Bolivia (Plurinational State of)": "Bolivia, Plurinational State of",
@@ -27,12 +27,12 @@ def fill_apha2(apps, schema_editor):
         "Virgin Islands (U.S.)": "Virgin Islands, U.S.",
     }
 
-    with open(
+    with open(  # noqa
         path.join(settings.BASE_DIR, "uploader", "fixtures", "countries.json")
     ) as countries_file:
         countries_records = json.load(countries_file)
 
-    countries_data = dict()
+    countries_data = dict()  # noqa
     for record in countries_records:
         fields = record["fields"]
         countries_data[fields["country"]] = fields["alpha2"]

--- a/dashboard_viewer/uploader/migrations/0012_auto_20210615_1828.py
+++ b/dashboard_viewer/uploader/migrations/0012_auto_20210615_1828.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("uploader", "0011_country_alpha2"),
     ]

--- a/dashboard_viewer/uploader/migrations/0013_auto_20210721_1715.py
+++ b/dashboard_viewer/uploader/migrations/0013_auto_20210721_1715.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("uploader", "0012_auto_20210615_1828"),
     ]

--- a/dashboard_viewer/uploader/tasks.py
+++ b/dashboard_viewer/uploader/tasks.py
@@ -10,6 +10,7 @@ from materialized_queries_manager.utils import refresh
 from .file_handler.checks import (
     check_for_duplicated_files,
     extract_data_from_uploaded_file,
+    upload_data_to_tmp_table,
 )
 from .file_handler.updates import update_achilles_results_data
 from .models import AchillesResults, PendingUpload, UploadHistory
@@ -51,6 +52,14 @@ def upload_results_file(pending_upload_id: int):
         file_metadata, data = extract_data_from_uploaded_file(
             pending_upload.uploaded_file
         )
+
+        logger.info(
+            "Validating if data is not corrupted [datasource %d, pending upload %d]",
+            data_source.id,
+            pending_upload_id,
+        )
+
+        upload_data_to_tmp_table(data_source.id, file_metadata, pending_upload)
 
         cache = caches["workers_locks"]
 

--- a/dashboard_viewer/uploader/tests.py
+++ b/dashboard_viewer/uploader/tests.py
@@ -135,7 +135,7 @@ class UpdateAchillesResultsDataTestCase(TransactionTestCase):
     fixtures = ("countries", "two_data_sources")
 
     def __init__(self, *args, **kwargs):
-        super(UpdateAchillesResultsDataTestCase, self).__init__(*args, **kwargs)
+        super(UpdateAchillesResultsDataTestCase, self).__init__(*args, **kwargs)  # noqa
         self._logger = logging.getLogger(UpdateAchillesResultsDataTestCase.__name__)
         self._pending_upload = PendingUpload(
             id=1,
@@ -359,7 +359,7 @@ class ExtractDataFromUploadedFileTestCase(TestCase):
 
         file_metadata, metadata = extract_data_from_uploaded_file(self.file_7)
 
-        self.assertEquals(
+        self.assertEquals(  # noqa
             metadata,
             {
                 "generation_date": "0",
@@ -371,7 +371,7 @@ class ExtractDataFromUploadedFileTestCase(TestCase):
             },
         )
 
-        self.assertEquals(
+        self.assertEquals(  # noqa
             file_metadata, UpdateAchillesResultsDataTestCase.file_metadata
         )
 

--- a/dashboard_viewer/utils/fix_dates.py
+++ b/dashboard_viewer/utils/fix_dates.py
@@ -97,7 +97,7 @@ def _convert_value(valid_pattern: re.Pattern, value: str):
         return None
     # print(f"unexpected date format -{value}-")
     # return None
-    raise Exception(f"unexpected date format -{value}-")
+    raise Exception(f"unexpected date format -{value}-")  # noqa
 
 
 @transaction.atomic


### PR DESCRIPTION
Adds a check that verifies if the data being inserted when uploading a file is valid or not, namely by running the materialized views against the new data that is being uploaded, to prevent the insertion of corrupted data. 

## Description
Before uploading the data to achilles_results, it creates a "temporary" table to store the new data being uploaded and runs the materialized views against this table, that only contains the data that is currently trying to be uploaded. If the process occurs with no errors, meaning that the materialized views are populated with the new data with success, it continues the uploading process. 

## Related Issue
Fixes #269 

## Motivation and Context
The refresh of the materialized views is prone to errors when data that is inserted is corrupted. Therefore, to prevent this from occurring, it should run the materialized views for the file being uploaded and stop the upload if the data is not valid for the materialized views. 