### PR TITLE
Change message in uploader views when no data is available

### DIFF
--- a/dashboard_viewer/uploader/templates/no_uploads_dashboard.html
+++ b/dashboard_viewer/uploader/templates/no_uploads_dashboard.html
@@ -17,6 +17,6 @@
   </style>
 </head>
 <body>
-  <h4>No data available: This database was not yet mapped into the CDM</h4>
+  <h4>No data is available at this moment</h4>
 </body>
 </html>


### PR DESCRIPTION
This PR changes the message when we are trying to access the dashboards, but no data is available to "No data is available at this moment", showing therefore a more descriptive message.
