### PR TITLE
Add New Validation upload

### DIFF
--- a/dashboard_viewer/uploader/file_handler/checks.py
+++ b/dashboard_viewer/uploader/file_handler/checks.py
@@ -375,14 +375,14 @@ def upload_data_to_tmp_table(data_source_id, file_metadata, pending_upload):
                     + AchillesResults._meta.db_table
                     + " WHERE FALSE"
                 )
-                cursor.execute("CREATE SEQUENCE IF NOT EXISTS seq_id")
+                cursor.execute("CREATE SEQUENCE IF NOT EXISTS achilles_results_tmp_seq_id")
                 cursor.execute(
-                    "ALTER TABLE achilles_results_tmp ALTER COLUMN id SET DEFAULT nextval('seq_id')"
+                    "ALTER TABLE achilles_results_tmp ALTER COLUMN id SET DEFAULT nextval('achilles_results_tmp_seq_id')"
                 )
                 cursor.execute(
                     "ALTER TABLE achilles_results_tmp ALTER COLUMN id SET NOT NULL"
                 )
-                cursor.execute("SELECT setval('seq_id', 1)")
+                cursor.execute("SELECT setval('achilles_results_tmp_seq_id', 1)")
 
                 # Upload data into "Temporary Table", similar structure to the actual upload process
                 for chunk in reader:

--- a/dashboard_viewer/uploader/file_handler/checks.py
+++ b/dashboard_viewer/uploader/file_handler/checks.py
@@ -6,8 +6,12 @@ import os
 import numpy
 import pandas
 from django.conf import settings
+from django.core.cache import caches
+from django.db import connections, transaction, utils
+from redis_rw_lock import RWLock
 
-from uploader.models import DataSource, UploadHistory
+from materialized_queries_manager.models import MaterializedQuery
+from uploader.models import AchillesResults, DataSource, UploadHistory
 
 
 class FileChecksException(Exception):
@@ -35,6 +39,9 @@ class MissingFieldValue(FileChecksException):
 
 
 class EqualFileAlreadyUploaded(FileChecksException):
+    pass
+
+class FileDataCorrupted(FileChecksException):
     pass
 
 
@@ -311,3 +318,101 @@ def check_for_duplicated_files(uploaded_file, data_source_id):
         pass
 
     #### Added For Checksum ##########################
+
+def upload_data_to_tmp_table(data_source_id, file_metadata, pending_upload):
+    # Upload New Data to a "temporary" table
+    pending_upload.uploaded_file.seek(0)
+
+    reader = pandas.read_csv(
+        pending_upload.uploaded_file,
+        header=0,
+        dtype=file_metadata["types"],
+        skip_blank_lines=False,
+        index_col=False,
+        names=file_metadata["columns"],
+        chunksize=500,
+    )
+
+    all_mat_views = MaterializedQuery.objects.exclude(matviewname__contains="tmp")
+
+    mat_views = {}
+
+    for mat_view in all_mat_views:
+        tmp_mat_view_name = mat_view.to_dict()["matviewname"] + "_tmp"
+
+        # To run the mat views (with data) against the "temporary table"
+        # To run for all mat views, as the data source can become with draft equal to true
+
+        tmp_definition = mat_view.to_dict()["definition"].replace(
+            "achilles_results", "achilles_results_tmp"
+        )
+
+        mat_views[tmp_mat_view_name] = [
+            tmp_definition,
+        ]
+
+        # since draft can change with time, we must run the queries for all types of draft, namely with draft = true and draft = false
+        if "draft = false" in tmp_definition:
+            mat_views[tmp_mat_view_name].append(
+                tmp_definition.replace("draft = false", "draft = true")
+            )
+
+    # Create "Temporary Upload" table, to store the data being uploaded
+    # Refresh of Materialized views does not allow the refresh in Temporary Tables
+
+    cache = caches["workers_locks"]  # To lock
+
+    with RWLock(
+        cache.client.get_client(), "celery_worker_updating", RWLock.WRITE, expire=None
+    ):
+        with transaction.atomic(), connections[
+            "achilles"
+        ].cursor() as cursor, settings.ACHILLES_DB_SQLALCHEMY_ENGINE.connect() as pandas_connection, pandas_connection.begin():
+            try:
+                cursor.execute("DROP TABLE IF EXISTS achilles_results_tmp CASCADE")
+                cursor.execute(
+                    "CREATE TABLE IF NOT EXISTS achilles_results_tmp AS SELECT * FROM "
+                    + AchillesResults._meta.db_table
+                    + " WHERE FALSE"
+                )
+                cursor.execute("CREATE SEQUENCE IF NOT EXISTS seq_id")
+                cursor.execute(
+                    "ALTER TABLE achilles_results_tmp ALTER COLUMN id SET DEFAULT nextval('seq_id')"
+                )
+                cursor.execute(
+                    "ALTER TABLE achilles_results_tmp ALTER COLUMN id SET NOT NULL"
+                )
+                cursor.execute("SELECT setval('seq_id', 1)")
+
+                # Upload data into "Temporary Table", similar structure to the actual upload process
+                for chunk in reader:
+                    chunk = chunk[chunk["stratum_1"].isin(["0"]) == False]  # noqa
+                    chunk = chunk.assign(data_source_id=data_source_id)
+                    chunk.to_sql(
+                        "achilles_results_tmp",
+                        pandas_connection,
+                        if_exists="append",
+                        index=False,
+                    )
+            except Exception:
+                raise InvalidCSVFile("Error processing the file")
+
+        # Fetch Materialized Views
+        # The option here is to change the definitions of the original mat views and replace
+        # the achilles_results references to achilles_results_tmp
+
+        with transaction.atomic(), connections["achilles"].cursor() as cursor:
+            try:
+                for tmp_mat_view_name in mat_views:  # noqa
+                    for tmp_definition in mat_views[tmp_mat_view_name]:
+                        cursor.execute(
+                            f"CREATE MATERIALIZED VIEW {tmp_mat_view_name} AS {tmp_definition}"
+                        )
+                        cursor.execute(f"DROP MATERIALIZED VIEW {tmp_mat_view_name}")
+            except utils.DataError:
+                cursor.execute("DROP TABLE IF EXISTS achilles_results_tmp CASCADE")
+                raise FileDataCorrupted("Uploaded file is not valid")
+
+        # Delete Temprary Upload data and its dependent (Materialzied Views)
+        with transaction.atomic(), connections["achilles"].cursor() as cursor:
+            cursor.execute("DROP TABLE IF EXISTS achilles_results_tmp CASCADE")

--- a/dashboard_viewer/uploader/file_handler/checks.py
+++ b/dashboard_viewer/uploader/file_handler/checks.py
@@ -382,7 +382,6 @@ def upload_data_to_tmp_table(data_source_id, file_metadata, pending_upload):
                 cursor.execute(
                     "ALTER TABLE achilles_results_tmp ALTER COLUMN id SET NOT NULL"
                 )
-                cursor.execute("SELECT setval('achilles_results_tmp_seq_id', 1)")
 
                 # Upload data into "Temporary Table", similar structure to the actual upload process
                 for chunk in reader:

--- a/dashboard_viewer/uploader/tasks.py
+++ b/dashboard_viewer/uploader/tasks.py
@@ -10,6 +10,7 @@ from materialized_queries_manager.utils import refresh
 from .file_handler.checks import (
     check_for_duplicated_files,
     extract_data_from_uploaded_file,
+    upload_data_to_tmp_table,
 )
 from .file_handler.updates import update_achilles_results_data
 from .models import AchillesResults, PendingUpload, UploadHistory
@@ -51,6 +52,14 @@ def upload_results_file(pending_upload_id: int):
         file_metadata, data = extract_data_from_uploaded_file(
             pending_upload.uploaded_file
         )
+
+        logger.info(
+            "Validating if data is not corrupted [datasource %d, pending upload %d]",
+            data_source.id,
+            pending_upload_id,
+        )
+
+        upload_data_to_tmp_table(data_source.id, file_metadata, pending_upload)
 
         cache = caches["workers_locks"]
 


### PR DESCRIPTION
Adds a check that verifies if the data being inserted when uploading a file is valid or not, namely by running the materialized views against the new data that is being uploaded, to prevent the insertion of corrupted data. 

## Description
Before uploading the data to achilles_results, it creates a "temporary" table to store the new data being uploaded and runs the materialized views against this table, that only contains the data that is currently trying to be uploaded. If the process occurs with no errors, meaning that the materialized views are populated with the new data with success, it continues the uploading process. 

## Related Issue
Fixes #269 

## Motivation and Context
The refresh of the materialized views is prone to errors when data that is inserted is corrupted. Therefore, to prevent this from occurring, it should run the materialized views for the file being uploaded and stop the upload if the data is not valid for the materialized views. 