### PR TITLE
Add verification of pending upload file in Duplicate file verification

### DIFF
--- a/dashboard_viewer/uploader/file_handler/checks.py
+++ b/dashboard_viewer/uploader/file_handler/checks.py
@@ -270,10 +270,8 @@ def _get_upload_attr(analysis, stratum):
 
 
 def check_for_duplicated_files(uploaded_file, data_source_id):
-    #### Added For Checksum ##########################
-
     try:
-        # Upload History only stores the succesded files
+        # Upload History only stores the succeded files
 
         pd = UploadHistory.objects.filter(data_source_id=data_source_id).latest()
 
@@ -283,8 +281,8 @@ def check_for_duplicated_files(uploaded_file, data_source_id):
             .first()
         )
 
-        if data_source_hash is not None:
-            # Go to the path where sucess filea are stored
+        if data_source_hash is not None and bool(pd.uploaded_file):
+            # Go to the path where success files are stored
 
             latest_file_path = os.path.join(settings.MEDIA_ROOT, pd.uploaded_file.path)
 
@@ -317,7 +315,6 @@ def check_for_duplicated_files(uploaded_file, data_source_id):
     except UploadHistory.DoesNotExist:
         pass
 
-    #### Added For Checksum ##########################
 
 def upload_data_to_tmp_table(data_source_id, file_metadata, pending_upload):
 


### PR DESCRIPTION
## Motivation and Context

Currently, issues when uploading a file related to the check of duplicated files can occur if the upload history presents its upload_file as not available, which may stop the upload of files that are completely fine. These changes alter this behavior, if a valid entry is not found and allow the upload to proceed to next steps.
