### PR TITLE
Improve logging in upload, add a refresh timeout for MaterializedViews

### DIFF
--- a/dashboard_viewer/dashboard_viewer/settings.py
+++ b/dashboard_viewer/dashboard_viewer/settings.py
@@ -345,6 +345,11 @@ CONSTANCE_CONFIG = {
         "Css for the img tag displaying the app logo",
         str,
     ),
+    "REFRESH_MATERIALIZED_TIMEOUT": (
+        7200000,
+        "Refresh materialized view statement timeout in POSTGRES (in ms). Default: 2hrs",
+        int,
+    ),
 }
 
 CONSTANCE_CONFIG_FIELDSETS = OrderedDict(
@@ -361,7 +366,7 @@ CONSTANCE_CONFIG_FIELDSETS = OrderedDict(
         ("Uploader Settings", ("UPLOADER_ALLOW_EDIT_DRAFT_STATUS",)),
         (
             "Superset",
-            ("SUPERSET_HOST", "DATABASE_DASHBOARD_IDENTIFIER", "DATABASE_FILTER_ID"),
+            ("SUPERSET_HOST", "DATABASE_DASHBOARD_IDENTIFIER", "DATABASE_FILTER_ID", "REFRESH_MATERIALIZED_TIMEOUT"),
         ),
         ("Tabs (Deprecated)", ("TABS_LOGO_CONTAINER_CSS", "TABS_LOGO_IMG_CSS")),
     ]

--- a/dashboard_viewer/materialized_queries_manager/utils.py
+++ b/dashboard_viewer/materialized_queries_manager/utils.py
@@ -1,7 +1,7 @@
 from django.core.cache import caches
 from django.db import connections
 from redis_rw_lock import RWLock
-
+import constance
 from materialized_queries_manager.models import MaterializedQuery
 
 
@@ -24,6 +24,7 @@ def refresh(logger, db_id=None, query_set=None):
 
             for i, materialized_query in enumerate(to_refresh):
                 try:
+                    cursor.execute("SET statement_timeout = " + str(constance.config.REFRESH_MATERIALIZED_TIMEOUT) + ";")
                     logger.info(
                         "Refreshing materialized view %s (%d/%d) [%s]",
                         materialized_query.matviewname,
@@ -37,6 +38,6 @@ def refresh(logger, db_id=None, query_set=None):
                 except:  # noqa
                     logger.exception(
                         "Some unexpected error happen while refreshing materialized query %s. [%s]",
-                        materialized_query.name,
+                        materialized_query.matviewname,
                         "command" if not db_id else f"datasource {db_id}",
                     )

--- a/dashboard_viewer/uploader/tasks.py
+++ b/dashboard_viewer/uploader/tasks.py
@@ -91,13 +91,19 @@ def upload_results_file(pending_upload_id: int):
                 )
 
                 logger.info(
-                    "Creating an upload history record [datasource %d, pending upload %d]",
+                    "Saving data source release date [datasource %d, pending upload %d]",
                     data_source.id,
                     pending_upload_id,
                 )
 
                 data_source.release_date = data["source_release_date"]
                 data_source.save()
+
+                logger.info(
+                    "Creating an upload history record [datasource %d, pending upload %d]",
+                    data_source.id,
+                    pending_upload_id,
+                )
 
                 pending_upload.uploaded_file.seek(0)
                 UploadHistory.objects.create(
@@ -111,7 +117,21 @@ def upload_results_file(pending_upload_id: int):
                     pending_upload_id=pending_upload.id,
                 )
 
+                logger.info(
+                    "Deleting pending upload files [datasource %d, pending upload %d, pending upload file %s]",
+                    data_source.id,
+                    pending_upload_id,
+                    pending_upload.uploaded_file.file
+                )
+
                 pending_upload.uploaded_file.delete()
+
+                logger.info(
+                    "Deleting pending upload [datasource %d, pending upload %d]",
+                    data_source.id,
+                    pending_upload_id
+                )
+
                 pending_upload.delete()
 
         finally:


### PR DESCRIPTION
## Motivation and Context

Try to fix some issues related with locks in Network Dashboards, by adding a statement timeout to refresh of materialized views to prevent it from occupying too much resources and allow to dealloc the db to other activities when we have a long running materialized view. Additionally, some logging was also added to try to identify an issue that happened with upload that failed after creating an history record.

## Summary
- Statement timeout when executing a reresh of materiailized, raises a timeout exception . If one fails, the process of the other materialized views continues. The default is set to 2h for each one, but can be changed in Constance config.
- Logging in upload to target the area where the upload got stuck




